### PR TITLE
Update old dea repo ref's, fix remote data source assignments

### DIFF
--- a/cfg/SharpTimer/discordConfig.json
+++ b/cfg/SharpTimer/discordConfig.json
@@ -1,7 +1,7 @@
 {
     "DiscordWebhookBotName": "SharpTimer",
     "DiscordWebhookPFPUrl": "https://cdn.discordapp.com/icons/1196646791450472488/634963a8207fdb1b30bf909d31f05e57.webp",
-    "DiscordWebhookMapImageRepoUrl": "https://raw.githubusercontent.com/deafps/SharpTimerDiscordWebhookMapPics/main/images/",
+    "DiscordWebhookMapImageRepoUrl": "https://raw.githubusercontent.com/Letaryat/poor-sharptimermappics/main/pics/",
     "DiscordPBWebhookUrl": "your_discord_webhook_url",
     "DiscordSRWebhookUrl": "your_discord_webhook_url",
     "DiscordPBBonusWebhookUrl": "your_discord_webhook_url",

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -792,7 +792,7 @@ namespace SharpTimer
 
             if (string.IsNullOrEmpty(args))
             {
-                remoteBhopDataSource = $"https://raw.githubusercontent.com/deafps/SharpTimer/remote_data/bhop_.json";
+                remoteBhopDataSource = $"https://raw.githubusercontent.com/Letaryat/poor-SharpTimer/main/remote_data/bhop_.json";
                 return;
             }
 
@@ -808,7 +808,7 @@ namespace SharpTimer
 
             if (string.IsNullOrEmpty(args))
             {
-                remoteBhopDataSource = $"https://raw.githubusercontent.com/deafps/SharpTimer/remote_data/kz_.json";
+                remoteKZDataSource = $"https://raw.githubusercontent.com/Letaryat/poor-SharpTimer/main/remote_data/kz_.json";
                 return;
             }
 
@@ -824,7 +824,7 @@ namespace SharpTimer
 
             if (string.IsNullOrEmpty(args))
             {
-                remoteBhopDataSource = $"https://raw.githubusercontent.com/deafps/SharpTimer/remote_data/surf_.json";
+                remoteSurfDataSource = $"https://raw.githubusercontent.com/Letaryat/poor-SharpTimer/main/remote_data/surf_.json";
                 return;
             }
 


### PR DESCRIPTION
This updates the default placeholder discord map image repo URL in the discord config. It also updates some lingering dea repo URLs in the cfg convars as well as fixing how those were being assigned. They all were being assigned to the `remoteBhopDataSource` instead of their respective data sources.