### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> The original creator of SharpTimer is deadps, who discontinued support for the project after version 0.2.6. This fork is now maintaned by the community, mainly [rcnoob](https://github.com/rcnoob).
+> The original creator of SharpTimer is deafps, who discontinued support for the project after version 0.2.6. This fork is now maintaned by the community, mainly [rcnoob](https://github.com/rcnoob).
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-> [!CAUTION]
-> ORIGINAL CREATOR IS DEAFPS_ I JUST YOINKED THE REMAINING COPY AND EDITED SO TESTER GIFS WOULD WORK JUST FINE.
+> [!NOTE]
+> The original creator of SharpTimer is deadps, who discontinued support for the project after version 0.2.6. This fork of is now maintaned by the community, mainly [rcnoob](https://github.com/rcnoob).
 
-> [!CAUTION]
-> This project will not receive any further updates as im unable to continue working on it. Thank you for all the support and time spend testing the pre-release versions. Feel free to fork and yoink anything you want and build upon it
+
 
 [**Discord**](https://discord.com/invite/SmQXeyMcny)
 
 <div align="center">
-  <img src="https://github.com/DEAFPS/SharpTimer/assets/43534349/c353662a-eb64-43e7-9294-40cfed3d58af" alt="" style="margin: 0;">
+  <img src="https://files.catbox.moe/qvawnf.png" alt="" style="margin: 0;">
 </div>
 
 
@@ -86,6 +85,8 @@ SharpTimer is a "simple" Surf/KZ/Bhop/MG/Deathrun/etc. CS2 Timer plugin using Co
 [**SharpTimerModelSetter** *(optional but recommended for custom player models)*](https://github.com/DEAFPS/SharpTimerModelSetter/)
 
 [**MovementUnlocker** *(optional but recommended)*](https://github.com/Source2ZE/MovementUnlocker)
+
+[**CS2Fixes-RampbugFix** *(optional but recommended)*](https://github.com/Interesting-exe/CS2Fixes-RampbugFix)
 
 [**Web panel** *(optional but recommended)*](https://github.com/Letaryat/sharptimer-web-panel)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-> The original creator of SharpTimer is deadps, who discontinued support for the project after version 0.2.6. This fork of is now maintaned by the community, mainly [rcnoob](https://github.com/rcnoob).
+> The original creator of SharpTimer is deadps, who discontinued support for the project after version 0.2.6. This fork is now maintaned by the community, mainly [rcnoob](https://github.com/rcnoob).
 
 
 


### PR DESCRIPTION
- Replaced the caution messages with a note to indicate the current state of the fork so that people know this is a usable plugin.
- Replaced dead SharpTimer banner URL.
- Added a link to the ramp bug fix as an optional but recommended dependency.
