### PR TITLE
Fix bonus replay saving and checks for !btop

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -238,11 +238,11 @@ namespace SharpTimer
             {
                 if (useMySQL)
                 {
-                    (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamIDFromDatabase(0, top10);
+                    (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamIDFromDatabase(bonusX, top10);
                 }
                 else
                 {
-                    (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamID();
+                    (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamID(bonusX, top10);
                 }
             }
 
@@ -637,7 +637,7 @@ namespace SharpTimer
                 int timerTicks = kvp.Value.TimerTicks;
 
                 bool showReplays = false;
-                if (enableReplays == true) showReplays = await CheckSRReplay(kvp.Key);
+                if (enableReplays == true) showReplays = await CheckSRReplay(kvp.Key, bonusX);
 
                 printStatements.Add($"{msgPrefix} #{rank}: {primaryChatColor}{_playerName} {ChatColors.White}- {(enableReplays ? $"{(showReplays ? $" {ChatColors.Red}◉" : "")}" : "")}{primaryChatColor}{FormatTime(timerTicks)}");
                 rank++;

--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -845,7 +845,7 @@ namespace SharpTimer
 
         public async Task<(string, string, string)> GetMapRecordSteamIDFromDatabase(int bonusX = 0, int top10 = 0)
         {
-            SharpTimerDebug($"Trying to get map record steamid from mysql");
+            SharpTimerDebug($"Trying to get {(bonusX != 0 ? $"bonus {bonusX}" : "map")} record steamid from mysql");
             try
             {
                 using (var connection = await OpenDatabaseConnectionAsync())
@@ -870,7 +870,7 @@ namespace SharpTimer
 
                     using (var selectCommand = new MySqlCommand(selectQuery, connection))
                     {
-                        selectCommand.Parameters.AddWithValue("@MapName", currentMapName);
+                        selectCommand.Parameters.AddWithValue("@MapName", bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}");
 
                         var row = await selectCommand.ExecuteReaderAsync();
 

--- a/src/Features/ReplayUtils.cs
+++ b/src/Features/ReplayUtils.cs
@@ -346,23 +346,23 @@ namespace SharpTimer
             }
         }
 
-        public async Task<bool> CheckSRReplay(string topSteamID = "x")
+        public async Task<bool> CheckSRReplay(string topSteamID = "x", int bonusX = 0)
         {
             var (srSteamID, srPlayerName, srTime) = ("null", "null", "null");
 
             if (useMySQL)
             {
-                (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamIDFromDatabase();
+                (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamIDFromDatabase(bonusX);
             }
             else
             {
-                (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamID();
+                (srSteamID, srPlayerName, srTime) = await GetMapRecordSteamID(bonusX);
             }
 
             if ((srSteamID == "null" || srPlayerName == "null" || srTime == "null") && topSteamID != "x") return false;
 
             string fileName = $"{(topSteamID == "x" ? $"{srSteamID}" : $"{topSteamID}")}_replay.json";
-            string playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", currentMapName, fileName);
+            string playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), fileName);
 
             try
             {

--- a/src/Player/PlayerOnTick.cs
+++ b/src/Player/PlayerOnTick.cs
@@ -236,7 +236,7 @@ namespace SharpTimer
 
                         if (enableReplays)
                         {
-                            if (!playerTimer.IsReplaying && timerTicks > 0 && playerTimer.IsRecordingReplay && !isTimerBlocked)
+                            if (!playerTimer.IsReplaying && (timerTicks > 0 || playerTimer.BonusTimerTicks > 0) && playerTimer.IsRecordingReplay && !isTimerBlocked)
                             {
                                 ReplayUpdate(player, timerTicks);
                             }


### PR DESCRIPTION
This fixes an issue where bonus replays were not saving correctly, the files were just empty. This now updates replay frames correctly for bonuses. 

This also fixes an issue that was happening when displaying the replay dot next to names when doing !btop. The !btop now correctly checks for placement on the bonus stage instead of just the main map and also looks for the replay file in the correct directory.