### PR TITLE
Trigger bug fix 

### DIFF
--- a/src/Hooks/TriggerHooks.cs
+++ b/src/Hooks/TriggerHooks.cs
@@ -130,8 +130,9 @@ namespace SharpTimer
                 }
 
                 var (validStartBonus, startBonusX) = IsValidStartBonusTriggerName(callerName);
+                var (validStartFakeBonus, fakeBonusX) = IsValidFakeStartBonusTriggerName(callerName);
 
-                if (validStartBonus || totalBonuses.Contains(startBonusX))
+                if (validStartBonus || validStartFakeBonus)
                 {
                     if (!playerTimers[playerSlot].IsTimerBlocked)
                     {
@@ -151,10 +152,10 @@ namespace SharpTimer
                     {
                         InMainMapStartZone = false,
                         InBonusStartZone = true,
-                        CurrentBonusNumber = startBonusX
+                        CurrentBonusNumber = (startBonusX != 0 ? startBonusX : fakeBonusX)
                     };
 
-                    SharpTimerDebug($"Player {playerName} entered Bonus {startBonusX} StartZone");
+                    SharpTimerDebug($"Player {playerName} entered Bonus {(startBonusX != 0 ? startBonusX : fakeBonusX)} StartZone");
                     return HookResult.Continue;
                 }
 

--- a/src/Plugin/Utils.cs
+++ b/src/Plugin/Utils.cs
@@ -146,8 +146,6 @@ namespace SharpTimer
                     allAdMessages.AddRange(nonEmptyCustomAds);
                 }
 
-                SharpTimerDebug($"Ad message count: {allAdMessages.Count}");
-
                 Server.NextFrame(() => Server.PrintToChatAll($"{ReplaceAdMessagePlaceholders(allAdMessages[new Random().Next(allAdMessages.Count)])}"));
             }, TimerFlags.REPEAT);
 

--- a/src/Triggers/TriggerUtils.cs
+++ b/src/Triggers/TriggerUtils.cs
@@ -86,6 +86,50 @@ namespace SharpTimer
                 return (false, 0);
             }
         }
+        private (bool valid, int X) IsValidFakeStartBonusTriggerName(string triggerName)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(triggerName)) return (false, 0);
+
+                string[] patterns = [
+                    @"^b([1-9][0-9]?)_start$",
+                    @"^bonus([1-9][0-9]?)_start$",
+                    @"^timer_bonus([1-9][0-9]?)_startzone$"
+                ];
+
+                foreach (var pattern in patterns)
+                {
+                    var match = Regex.Match(triggerName, pattern);
+                    if (match.Success)
+                    {
+                        int X = int.Parse(match.Groups[1].Value);
+                        try
+                        {
+                            if (totalBonuses[X] != 0)
+                            {
+                                return (true, X);
+                            }
+                            else
+                            {
+                                return (false, X);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            return (true, X);
+                        }
+                    }
+                }
+
+                return (false, 0);
+            }
+            catch (Exception ex)
+            {
+                SharpTimerError($"Exception in IsValidFakeStartBonusTriggerName: {ex.Message}");
+                return (false, 0);
+            }
+        }
 
         private (bool valid, int X) IsValidStageTriggerName(string triggerName)
         {


### PR DESCRIPTION
Accidentally added a check to bonus start trigger that was almost always true. Fixed by creating a method to check that a fake bonus start zone trigger is valid. I want to eventually refactor the fake bonus zone setting and checks because this fix is ugly but it works for the time being.

Also remove a debug print in ad message method that was used for development. 