### PR TITLE
Added an option to have the HUD speed color change dynamically

### DIFF
--- a/cfg/SharpTimer/config.cfg
+++ b/cfg/SharpTimer/config.cfg
@@ -74,6 +74,7 @@ sharptimer_forced_player_speed                      250                         
 //HUD
 sharptimer_hud_primary_color                        #00FF00                                 // Primary Color for Timer HUD (you can use hex codes too). Default value: #00FF00 (green)
 sharptimer_hud_secondary_color                      #FFA500                                 // Secondary Color for Timer HUD (you can use hex codes too). Default value: #FFA500 (orange)
+sharptimer_hud_secondary_color_dynamic              false									                  // False = Use the sharptimer_hud_secondary_color color. True = Use dynamic color based on player velocity (surf only). Default value: false
 sharptimer_hud_tertiary_color                       #FFFFFF                                 // Tertiary Color for Timer HUD (you can use hex codes too). Default value: #FFFFFF (white)
 sharptimer_enable_timer_hud                         true                                    // If Timer Hud should be globally enabled or not. Default value: true
 sharptimer_enable_keys_hud                          true                                    // If Keys Hud should be globally enabled or not. Default value: true

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -813,6 +813,15 @@ namespace SharpTimer
             primaryHUDcolor = $"{args}";
         }
 
+        [ConsoleCommand("sharptimer_hud_secondary_color_dynamic", "Whether to use dynamic color for secondary HUD based on player speed. Default value: false")]
+        [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
+        public void SharpTimerHUDSecondaryColorDynamicConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            string args = command.ArgString;
+
+            useDynamicColor = bool.TryParse(args, out bool useDynamicColorValue) ? useDynamicColorValue : args != "0" && useDynamicColor;
+        }
+
         [ConsoleCommand("sharptimer_hud_secondary_color", "Secondary Color for Timer HUD. Default value: orange")]
         [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
         public void SharpTimerSecondaryHUDcolor(CCSPlayerController? player, CommandInfo command)

--- a/src/Player/PlayerOnTick.cs
+++ b/src/Player/PlayerOnTick.cs
@@ -70,6 +70,33 @@ namespace SharpTimer
                         string formattedPlayerVel = Math.Round(use2DSpeed ? playerSpeed.Length2D()
                                                                             : playerSpeed.Length())
                                                                             .ToString("0000");
+                        int playerVel = int.Parse(formattedPlayerVel);
+                        
+                        string secondaryHUDcolorDynamic = "LimeGreen";
+                        if (playerVel < 349)
+                            secondaryHUDcolorDynamic = "LimeGreen";
+                        else if (playerVel < 699)
+                            secondaryHUDcolorDynamic = "Lime";
+                        else if (playerVel < 1049)
+                            secondaryHUDcolorDynamic = "GreenYellow";
+                        else if (playerVel < 1399)
+                            secondaryHUDcolorDynamic = "Yellow";
+                        else if (playerVel < 1749)
+                            secondaryHUDcolorDynamic = "Gold";
+                        else if (playerVel < 2099)
+                            secondaryHUDcolorDynamic = "Orange";
+                        else if (playerVel < 2449)
+                            secondaryHUDcolorDynamic = "DarkOrange";
+                        else if (playerVel < 2799)
+                            secondaryHUDcolorDynamic = "Tomato";
+                        else if (playerVel < 3149)
+                            secondaryHUDcolorDynamic = "OrangeRed";
+                        else if (playerVel < 3499)
+                            secondaryHUDcolorDynamic = "Red";
+                        else
+                            secondaryHUDcolorDynamic = "Crimson";
+
+                        string playerVelColor = useDynamicColor ? secondaryHUDcolorDynamic : secondaryHUDcolor;
                         string formattedPlayerPre = Math.Round(ParseVector(playerTimer.PreSpeed ?? "0 0 0").Length2D()).ToString("000");
                         string playerTime = FormatTime(timerTicks);
                         string playerBonusTime = FormatTime(playerTimer.BonusTimerTicks);
@@ -81,7 +108,7 @@ namespace SharpTimer
                                                     ? $" <font class='horizontal-center' color='red'>◉ REPLAY {FormatTime(playerReplays[playerSlot].CurrentPlaybackFrame)}</font> <br>"
                                                     : "";
 
-                        string veloLine = $" {(playerTimer.IsTester ? playerTimer.TesterSmolGif : "")}<font class='fontSize-s stratum-bold-italic' color='{tertiaryHUDcolor}'>Speed:</font> {(playerTimer.IsReplaying ? "<font class=''" : "<font class='fontSize-l horizontal-center'")} color='{secondaryHUDcolor}'>{formattedPlayerVel}</font> <font class='fontSize-s stratum-bold-italic' color='gray'>({formattedPlayerPre})</font>{(playerTimer.IsTester ? playerTimer.TesterSmolGif : "")} <br>";
+                        string veloLine = $" {(playerTimer.IsTester ? playerTimer.TesterSmolGif : "")}<font class='fontSize-s stratum-bold-italic' color='{tertiaryHUDcolor}'>Speed:</font> {(playerTimer.IsReplaying ? "<font class=''" : "<font class='fontSize-l horizontal-center'")} color='{playerVelColor}'>{formattedPlayerVel}</font> <font class='fontSize-s stratum-bold-italic' color='gray'>({formattedPlayerPre})</font>{(playerTimer.IsTester ? playerTimer.TesterSmolGif : "")} <br>";
 
                         string syncLine = $"<font class='fontSize-s stratum-bold-italic' color='{tertiaryHUDcolor}'>Sync:</font> <font class='fontSize-l horizontal-center color='{secondaryHUDcolor}'>{playerTimer.Sync}%</font> <br>";
 

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -51,6 +51,7 @@ namespace SharpTimer
 
         public string primaryHUDcolor = "green";
         public string secondaryHUDcolor = "orange";
+        public bool useDynamicColor = false;
         public string tertiaryHUDcolor = "white";
         public string primaryChatColor = "";
         public string startBeamColor = "";


### PR DESCRIPTION
Added a configurable option to have the player HUD speed change dynamically based on their current speed, going from green -> red as speed increases. Set to false by default. Color/speed logic is only really applicable to surf. Currently only used on the main timer, not bonus or spectator.

- Added "SharpTimerHUDSecondaryColorDynamicConvar" to ConfigConvars.
- Added "playerVelColor" logic to PlayerOnTick.
- Added "useDynamicColor" to Globals.