### PR TITLE
Address OnSyncTick exception

### DIFF
--- a/src/Features/JumpStats.cs
+++ b/src/Features/JumpStats.cs
@@ -220,7 +220,7 @@ namespace SharpTimer
                 bool left = false;
                 bool right = false;
 
-                #pragma warning disable CS0219 // annoyence
+                #pragma warning disable CS0219 // annoyance
                 bool leftRight = false;
                 #pragma warning restore CS0219
 
@@ -236,14 +236,15 @@ namespace SharpTimer
                 playerTimer.Rotation.Add(newEyeAngle);
                 playerTimer.TotalSync++;
 
-                //Check left goodsync
-                if (playerTimer.Rotation != null && playerTimer.Rotation.Count > 1 && eyeangle.Y > playerTimer.Rotation[playerTimer.TotalSync - 2].Y && left)
-                    playerTimer.GoodSync++;
-
-                //Check right goodsync
-                if (playerTimer.Rotation != null && playerTimer.Rotation.Count > 1 && eyeangle.Y < playerTimer.Rotation[playerTimer.TotalSync - 2].Y && right)
-                    playerTimer.GoodSync++;
-
+                if (playerTimer.Rotation != null && playerTimer.Rotation.Count > 1 && playerTimer.TotalSync >= 2)
+                {
+                    if (eyeangle.Y > playerTimer.Rotation[playerTimer.TotalSync - 2].Y && left)
+                        playerTimer.GoodSync++;
+                
+                    if (eyeangle.Y < playerTimer.Rotation[playerTimer.TotalSync - 2].Y && right)
+                        playerTimer.GoodSync++;
+                }
+                
                 playerTimer.Sync = Math.Round((float)playerTimers[player.Slot].GoodSync / playerTimers[player.Slot].TotalSync * 100, 0);
             }
             catch (Exception ex)


### PR DESCRIPTION
Addresses the following exception:
```
[INFO] (plugin:SharpTimer) [SharpTimerDebug] Exception in OnSyncTick: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at SharpTimer.SharpTimer.OnSyncTick(CCSPlayerController player, Nullable`1 buttons, QAngle eyeangle)
```