### PR TITLE
Added CVAR 'sharptimer_enable' to enable/disable plugin functionality

### DIFF
--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -13,12 +13,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
-using CounterStrikeSharp.API.Modules.Entities;
-using CounterStrikeSharp.API.Modules.Utils;
 
 
 namespace SharpTimer

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -661,14 +661,17 @@ namespace SharpTimer
         {
             string args = command.ArgString;
 
-            if (int.TryParse(args, out int speed) && speed > 0)
+            if (!isDisabled)
             {
-                forcedPlayerSpeed = speed;
-                SharpTimerConPrint($"SharpTimer forced player speed set to {speed}.");
-            }
-            else
-            {
-                SharpTimerConPrint("Invalid forced player speed value. Please provide a positive integer.");
+                if (int.TryParse(args, out int speed) && speed > 0)
+                {
+                    forcedPlayerSpeed = speed;
+                    SharpTimerConPrint($"SharpTimer forced player speed set to {speed}.");
+                }
+                else
+                {
+                    SharpTimerConPrint("Invalid forced player speed value. Please provide a positive integer.");
+                }
             }
         }
 
@@ -1235,14 +1238,21 @@ namespace SharpTimer
             string args = command.ArgString.Trim();
             if (!string.IsNullOrEmpty(args))
             {
-                Boolean.TryParse(args, out var arg);
+                var parsed = Boolean.TryParse(args, out var arg);
 
-                if(args == "1" || arg)
+                if (!parsed && args != "1" && args != "0")
                 {
-                    EnablePlugin();
+                    Logger.LogInformation($"unexpected input: {args}");
                 } else
                 {
-                    DisablePlugin();
+                    if (args == "1" || arg)
+                    {
+                        EnablePlugin();
+                    }
+                    else
+                    {
+                        DisablePlugin();
+                    }
                 }
             } else
             {

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -13,6 +13,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
@@ -1226,6 +1227,24 @@ namespace SharpTimer
             }
 
             remoteSurfDataSource = $"{args}";
+        }
+
+        [ConsoleCommand("sharptimer_disable", "Disable SharpTimer")]
+        [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
+        public void SharpTimerDisable(CCSPlayerController? player, CommandInfo command)
+        {
+
+            string args = command.ArgString.Trim();
+
+            Boolean.TryParse(args, out var arg);
+
+            if(args == "1" || arg)
+            {
+                DisablePlugin();
+            } else
+            {
+                EnablePlugin();
+            }
         }
     }
 }

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -16,6 +16,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes.Registration;
 using CounterStrikeSharp.API.Modules.Commands;
+using Microsoft.Extensions.Logging;
 
 
 namespace SharpTimer
@@ -1226,21 +1227,26 @@ namespace SharpTimer
             remoteSurfDataSource = $"{args}";
         }
 
-        [ConsoleCommand("sharptimer_disable", "Disable SharpTimer")]
+        [ConsoleCommand("sharptimer_enable", "Enable SharpTimer")]
         [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
-        public void SharpTimerDisable(CCSPlayerController? player, CommandInfo command)
+        public void SharpTimerEnable(CCSPlayerController? player, CommandInfo command)
         {
 
             string args = command.ArgString.Trim();
-
-            Boolean.TryParse(args, out var arg);
-
-            if(args == "1" || arg)
+            if (!string.IsNullOrEmpty(args))
             {
-                DisablePlugin();
+                Boolean.TryParse(args, out var arg);
+
+                if(args == "1" || arg)
+                {
+                    EnablePlugin();
+                } else
+                {
+                    DisablePlugin();
+                }
             } else
             {
-                EnablePlugin();
+                Logger.LogInformation($"sharptimer_enable = {!isDisabled}.");
             }
         }
     }

--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -1272,6 +1272,7 @@ namespace SharpTimer
 
         public async Task SetPlayerStats(CCSPlayerController? player, string steamId, string playerName, int playerSlot)
         {
+            if(isDisabled) return;
             SharpTimerDebug($"Trying to set player stats in database for {playerName}");
             try
             {
@@ -1497,6 +1498,7 @@ namespace SharpTimer
             SharpTimerDebug($"Trying to set player points in database for {playerName}");
             try
             {
+                if (isDisabled) return;
                 int timeNowUnix = (int)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 // get player columns
                 int timesConnected = 0;

--- a/src/Hooks/Damage.cs
+++ b/src/Hooks/Damage.cs
@@ -71,7 +71,7 @@ namespace SharpTimer
         {
             var ent = h.GetParam<CEntityInstance>(0);
             var info = h.GetParam<CTakeDamageInfo>(1);
-            if(disableDamage) h.GetParam<CTakeDamageInfo>(1).Damage = 0;
+            if(disableDamage && !isDisabled) h.GetParam<CTakeDamageInfo>(1).Damage = 0;
 
             if (!ent.IsValid || !info.Attacker.IsValid)
                 return HookResult.Continue;
@@ -84,7 +84,7 @@ namespace SharpTimer
 
         HookResult OnPlayerHurt(EventPlayerHurt @event, GameEventInfo info)
         {
-            if (disableDamage == true)
+            if (disableDamage == true && !isDisabled)
             {
                 var player = @event.Userid;
 

--- a/src/Player/PlayerChecks.cs
+++ b/src/Player/PlayerChecks.cs
@@ -23,6 +23,7 @@ namespace SharpTimer
     {
         public bool IsAllowedPlayer(CCSPlayerController? player)
         {
+            if (isDisabled) return false;
             if (player == null || !player.IsValid || player.Pawn == null || !player.PlayerPawn.IsValid || !player.PawnIsAlive || playerTimers[player.Slot].IsNoclip)
             {
                 return false;

--- a/src/Player/PlayerEvents.cs
+++ b/src/Player/PlayerEvents.cs
@@ -53,6 +53,9 @@ namespace SharpTimer
                 string playerName = player.PlayerName;
 
                 initalizePlayer(player, isForBot);
+
+                if (connectMsgEnabled == true && !isDisabled) PrintToChatAll(Localizer["connect_message", player.PlayerName]);
+                if (cmdJoinMsgEnabled == true && !isDisabled) PrintAllEnabledCommands(player);
             }
             catch (Exception ex)
             {
@@ -108,9 +111,6 @@ namespace SharpTimer
 
                     //PlayerSettings
                     if (enableDb) _ = Task.Run(async () => await GetPlayerStats(player, steamID, playerName, playerSlot, true));
-
-                    if (connectMsgEnabled == true && !enableDb) PrintToChatAll(Localizer["connect_message", player.PlayerName]);
-                    if (cmdJoinMsgEnabled == true) PrintAllEnabledCommands(player);
 
                     SharpTimerDebug($"Added player {player.PlayerName} with UserID {player.UserId} to connectedPlayers");
                     SharpTimerDebug($"Total players connected: {connectedPlayers.Count}");
@@ -192,29 +192,29 @@ namespace SharpTimer
                 if (connectedPlayers.TryGetValue(player.Slot, out var connectedPlayer))
                 {
                     //schizo removing data from memory
-                    playerTimers[player.Slot] = new PlayerTimerInfo();
-                    playerTimers.Remove(player.Slot);
+                    playerTimers[connectedPlayer.Slot] = new PlayerTimerInfo();
+                    playerTimers.Remove(connectedPlayer.Slot);
 
                     //schizo removing data from memory
-                    playerCheckpoints[player.Slot] = new List<PlayerCheckpoint>();
-                    playerCheckpoints.Remove(player.Slot);
+                    playerCheckpoints[connectedPlayer.Slot] = new List<PlayerCheckpoint>();
+                    playerCheckpoints.Remove(connectedPlayer.Slot);
 
-                    specTargets.Remove(player.Pawn.Value!.EntityHandle.Index);
+                    specTargets.Remove(connectedPlayer.Pawn.Value!.EntityHandle.Index);
 
-                    playerTimers[player.Slot].TotalSync = 0;
-                    playerTimers[player.Slot].GoodSync = 0;
-                    playerTimers[player.Slot].Sync = 0;
-                    playerTimers[player.Slot].Rotation = new List<QAngle>();
+                    playerTimers[connectedPlayer.Slot].TotalSync = 0;
+                    playerTimers[connectedPlayer.Slot].GoodSync = 0;
+                    playerTimers[connectedPlayer.Slot].Sync = 0;
+                    playerTimers[connectedPlayer.Slot].Rotation = new List<QAngle>();
 
                     if (enableReplays)
                     {
                         //schizo removing data from memory
-                        playerReplays[player.Slot] = new PlayerReplays();
-                        playerReplays.Remove(player.Slot);
+                        playerReplays[connectedPlayer.Slot] = new PlayerReplays();
+                        playerReplays.Remove(connectedPlayer.Slot);
                     }
 
                     SharpTimerDebug($"Removed player {connectedPlayer.PlayerName} with UserID {connectedPlayer.UserId} from connectedPlayers.");
-                    SharpTimerDebug($"Removed specTarget index {player.Pawn.Value.EntityHandle.Index} from specTargets.");
+                    SharpTimerDebug($"Removed specTarget index {connectedPlayer.Pawn.Value.EntityHandle.Index} from specTargets.");
                     SharpTimerDebug($"Total players connected: {connectedPlayers.Count}");
                     SharpTimerDebug($"Total playerTimers: {playerTimers.Count}");
                     SharpTimerDebug($"Total specTargets: {specTargets.Count}");
@@ -234,12 +234,12 @@ namespace SharpTimer
 
         private HookResult OnPlayerChat(CCSPlayerController? player, CommandInfo message)
         {
-            if (displayChatTags == false)
+            if (displayChatTags == false || isDisabled)
                 return HookResult.Continue;
 
             string msg;
 
-            if (player == null || !player.IsValid || player.IsBot || string.IsNullOrEmpty(message.GetArg(1)) || isDisabled)
+            if (player == null || !player.IsValid || player.IsBot || string.IsNullOrEmpty(message.GetArg(1)))
                 return HookResult.Handled;
             else
                 msg = message.GetArg(1);

--- a/src/Player/PlayerEvents.cs
+++ b/src/Player/PlayerEvents.cs
@@ -53,55 +53,6 @@ namespace SharpTimer
                 string playerName = player.PlayerName;
 
                 initalizePlayer(player, isForBot);
-
-                /*try
-                {
-                    playerTimers[playerSlot] = new PlayerTimerInfo();
-                    playerJumpStats[playerSlot] = new PlayerJumpStats();
-                    if (enableReplays) playerReplays[playerSlot] = new PlayerReplays();
-                    playerTimers[playerSlot].MovementService = new CCSPlayer_MovementServices(player.PlayerPawn.Value.MovementServices!.Handle);
-                    playerTimers[playerSlot].StageTimes = new Dictionary<int, int>();
-                    playerTimers[playerSlot].StageVelos = new Dictionary<int, string>();
-                    if (AdminManager.PlayerHasPermissions(player, "@css/root")) playerTimers[playerSlot].ZoneToolWire = new Dictionary<int, CBeam>();
-                    playerTimers[playerSlot].CurrentMapStage = 0;
-                    playerTimers[playerSlot].CurrentMapCheckpoint = 0;
-                    SetNormalStyle(player);
-                    playerTimers[playerSlot].IsRecordingReplay = false;
-                    playerTimers[playerSlot].SetRespawnPos = null;
-                    playerTimers[playerSlot].SetRespawnAng = null;
-                    playerTimers[playerSlot].SoundsEnabled = soundsEnabledByDefault;
-
-                    if (isForBot == false) _ = Task.Run(async () => await IsPlayerATester(steamID, playerSlot));
-
-                    //PlayerSettings
-                    if (enableDb) _ = Task.Run(async () => await GetPlayerStats(player, steamID, playerName, playerSlot, true));
-
-                    if (connectMsgEnabled == true && !enableDb) PrintToChatAll(Localizer["connect_message", player.PlayerName]);
-                    if (cmdJoinMsgEnabled == true) PrintAllEnabledCommands(player);
-
-                    SharpTimerDebug($"Added player {player.PlayerName} with UserID {player.UserId} to connectedPlayers");
-                    SharpTimerDebug($"Total players connected: {connectedPlayers.Count}");
-                    SharpTimerDebug($"Total playerTimers: {playerTimers.Count}");
-                    SharpTimerDebug($"Total playerReplays: {playerReplays.Count}");
-
-                    if (removeLegsEnabled == true)
-                    {
-                        player.PlayerPawn.Value.Render = Color.FromArgb(254, 254, 254, 254);
-                        Utilities.SetStateChanged(player.PlayerPawn.Value, "CBaseModelEntity", "m_clrRender");
-                    }
-                }
-                finally
-                {
-                    if (connectedPlayers[playerSlot] == null)
-                    {
-                        connectedPlayers.Remove(playerSlot);
-                    }
-
-                    if (playerTimers[playerSlot] == null)
-                    {
-                        playerTimers.Remove(playerSlot);
-                    }
-                }*/
             }
             catch (Exception ex)
             {
@@ -187,7 +138,7 @@ namespace SharpTimer
             }
             catch (Exception ex)
             {
-                SharpTimerError($"Error in OnPlayerConnect: {ex.Message}");
+                SharpTimerError($"Error in initializePlayer: {ex.Message}");
             }
         }
 
@@ -217,34 +168,6 @@ namespace SharpTimer
                 {
 
                     clearInitializedPlayer(player, isForBot);
-
-                    /*//schizo removing data from memory
-                    playerTimers[player.Slot] = new PlayerTimerInfo();
-                    playerTimers.Remove(player.Slot);
-
-                    //schizo removing data from memory
-                    playerCheckpoints[player.Slot] = new List<PlayerCheckpoint>();
-                    playerCheckpoints.Remove(player.Slot);
-
-                    specTargets.Remove(player.Pawn.Value!.EntityHandle.Index);
-
-                    playerTimers[player.Slot].TotalSync = 0;
-                    playerTimers[player.Slot].GoodSync = 0;
-                    playerTimers[player.Slot].Sync = 0;
-                    playerTimers[player.Slot].Rotation = new List<QAngle>();
-
-                    if (enableReplays)
-                    {
-                        //schizo removing data from memory
-                        playerReplays[player.Slot] = new PlayerReplays();
-                        playerReplays.Remove(player.Slot);
-                    }
-
-                    SharpTimerDebug($"Removed player {connectedPlayer.PlayerName} with UserID {connectedPlayer.UserId} from connectedPlayers.");
-                    SharpTimerDebug($"Removed specTarget index {player.Pawn.Value.EntityHandle.Index} from specTargets.");
-                    SharpTimerDebug($"Total players connected: {connectedPlayers.Count}");
-                    SharpTimerDebug($"Total playerTimers: {playerTimers.Count}");
-                    SharpTimerDebug($"Total specTargets: {specTargets.Count}");*/
 
                     connectedPlayers.Remove(player.Slot);
 
@@ -304,7 +227,7 @@ namespace SharpTimer
             }
             catch (Exception ex)
             {
-                SharpTimerError($"Error in OnPlayerDisconnect (probably replay bot related lolxd): {ex.Message}");
+                SharpTimerError($"Error in clearInitializedPlayer (probably replay bot related lolxd): {ex.Message}");
             }
         }
 

--- a/src/Player/PlayerOnTick.cs
+++ b/src/Player/PlayerOnTick.cs
@@ -28,7 +28,7 @@ namespace SharpTimer
             {
                 foreach (CCSPlayerController player in connectedPlayers.Values)
                 {
-                    if (player == null || !player.IsValid) continue;
+                    if (player == null || !player.IsValid || isDisabled) continue;
 
                     var playerSlot = player.Slot;
 
@@ -219,7 +219,7 @@ namespace SharpTimer
                         {
                             if (playerTimer.TicksSinceLastRankUpdate > 511 &&
                             playerTimer.CachedRank != null &&
-                            (player.Clan != null || !player.Clan!.Contains($"[{playerTimer.CachedRank}]")))
+                            (player.Clan != null || !player.Clan!.Contains($"[{playerTimer.CachedRank}]") || !isDisabled))
                             {
                                 AddScoreboardTagToPlayer(player, playerTimer.CachedRank);
                                 playerTimer.TicksSinceLastRankUpdate = 0;

--- a/src/Player/PlayerUtils.cs
+++ b/src/Player/PlayerUtils.cs
@@ -26,6 +26,7 @@ namespace SharpTimer
     {
         public void PrintAllEnabledCommands(CCSPlayerController player)
         {
+            if(isDisabled) return;
             SharpTimerDebug($"Printing Commands for {player.PlayerName}");
             player.PrintToChat($" {Localizer["prefix"]} Available Commands:");
 

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -268,6 +268,8 @@ namespace SharpTimer
         public string UnrankedColor = "{default}";
         public static string UnrankedIcon = "https://raw.githubusercontent.com/Letaryat/poor-SharpTimer/main/remote_data/rank_icons/unranked.png";
 
+        public bool isDisabled = false;
+
         public List<RankData> rankDataList = new List<RankData>();
         public class RankData
         {

--- a/src/Plugin/Utils.cs
+++ b/src/Plugin/Utils.cs
@@ -131,7 +131,7 @@ namespace SharpTimer
 
         private void ADtimerMessages()
         {
-            if (isADMessagesTimerRunning) return;
+            if (isADMessagesTimerRunning || isDisabled) return;
 
             var timer = AddTimer(adMessagesTimer, () =>
             {
@@ -1543,6 +1543,58 @@ namespace SharpTimer
                 SharpTimerError($"Error GetClosestMapCFGMatch: {ex.StackTrace}");
                 return "null";
             }
+        }
+
+        public void DisablePlugin()
+        {
+            //set globals
+            isDisabled = true;
+
+            disableDamage = false;
+            fovChangerEnabled = false;
+
+            //ranks are known bugged rn
+            globalRanksEnabled = false;
+            rankEnabled = false;
+            displayChatTags = false;
+            displayScoreboardTags = false;
+
+            //de-init
+            foreach (var connectedPlayer in connectedPlayers)
+            {
+                var current = connectedPlayer.Value;
+                if (current.IsValid && !current.IsBot && connectedPlayer.Key != 0)
+                {
+                    clearInitializedPlayer(connectedPlayer.Value);
+                }
+            }
+
+            //movement
+            Server.ExecuteCommand("sv_timebetweenducks 0.4");
+        }
+
+        public void EnablePlugin()
+        {
+            //set globals
+            isDisabled = false;
+
+            disableDamage = true;
+            fovChangerEnabled = true;
+
+            //ranks are known bugged rn
+            globalRanksEnabled = true;
+            rankEnabled = true;
+            displayChatTags = true;
+            displayScoreboardTags = true;
+
+            //init
+            foreach (var connectedPlayer in connectedPlayers)
+            {
+                initalizePlayer(connectedPlayer.Value);
+            }
+
+            //movement
+            Server.ExecuteCommand("sv_timebetweenducks 0");
         }
     }
 }

--- a/src/Plugin/Utils.cs
+++ b/src/Plugin/Utils.cs
@@ -1553,6 +1553,8 @@ namespace SharpTimer
             disableDamage = false;
             fovChangerEnabled = false;
 
+            removeCrouchFatigueEnabled = false;
+
             //ranks are known bugged rn
             globalRanksEnabled = false;
             rankEnabled = false;
@@ -1567,10 +1569,14 @@ namespace SharpTimer
                 {
                     clearInitializedPlayer(connectedPlayer.Value);
                 }
+
+                //this is a movement thing
+                playerTimers.TryGetValue(current.Slot, out PlayerTimerInfo? playerTimer);
+                playerTimer.MovementService.DuckSpeed = 8.0f;
             }
 
             //movement
-            Server.ExecuteCommand("sv_timebetweenducks 0.4");
+            Server.ExecuteCommand("sv_timebetweenducks 0.400000");
         }
 
         public void EnablePlugin()
@@ -1587,14 +1593,21 @@ namespace SharpTimer
             displayChatTags = true;
             displayScoreboardTags = true;
 
+            removeCrouchFatigueEnabled = true;
+
             //init
             foreach (var connectedPlayer in connectedPlayers)
             {
-                initalizePlayer(connectedPlayer.Value);
+                var current = connectedPlayer.Value;
+                initalizePlayer(current);
+
+                //this is a movement thing
+                playerTimers.TryGetValue(current.Slot, out PlayerTimerInfo? playerTimer);
+                playerTimer.MovementService.DuckSpeed = 7.0f;
             }
 
             //movement
-            Server.ExecuteCommand("sv_timebetweenducks 0");
+            Server.ExecuteCommand("sv_timebetweenducks 0.000000");
         }
     }
 }

--- a/src/SharpTimer.cs
+++ b/src/SharpTimer.cs
@@ -141,7 +141,7 @@ namespace SharpTimer
 
                 AddTimer(3.0f, () =>
                 {
-                    if (enableDb && playerTimers.ContainsKey(player.Slot) && player.DesiredFOV != (uint)playerTimers[player.Slot].PlayerFov)
+                    if (enableDb && !isDisabled && playerTimers.ContainsKey(player.Slot) && player.DesiredFOV != (uint)playerTimers[player.Slot].PlayerFov)
                     {
                         SharpTimerDebug($"{player.PlayerName} has wrong PlayerFov {player.DesiredFOV}... SetFov to {(uint)playerTimers[player.Slot].PlayerFov}");
                         SetFov(player, playerTimers[player.Slot].PlayerFov, true);


### PR DESCRIPTION
fix for: https://github.com/Letaryat/poor-sharptimer/issues/99

wrote up a cvar to allow for enabling/disabling the plugin without restarting the server.

`sharptimer_enable 1` or `true` in any variant for enabling
`sharptimer_enable 0` or `false` in any variant for disabling
no args will print current status
any other args will do nothing

list of tests run:
![image](https://github.com/user-attachments/assets/408bb949-bf31-4b56-bab6-061b9e20e1f8)

known bugs:
-feet contact shadows sometimes remain after re-enabling plugin
-ad text still prints
-an error on disconnect

also: ranks showing/hiding doesn't _quite_ work right at the moment, but that should be fixed here: https://github.com/Letaryat/poor-sharptimer/pull/98

will make changes for ^^ if necessary after the other PR is in