### PR TITLE
feat: add SslMode option on MysqlConfig

### DIFF
--- a/cfg/SharpTimer/mysqlConfig.json
+++ b/cfg/SharpTimer/mysqlConfig.json
@@ -5,5 +5,6 @@
     "Password": "your_mysql_password",
     "TablePrefix": "",
     "Port": 3306,
-    "Timeout": 30
+    "Timeout": 30,
+    "SslMode": "Preferred"
 }

--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -166,13 +166,14 @@ namespace SharpTimer
                             string password = root.TryGetProperty("Password", out var passwordProperty) ? passwordProperty.GetString()! : "root";
                             int port = root.TryGetProperty("Port", out var portProperty) ? portProperty.GetInt32()! : 3306;
                             string tableprefix = root.TryGetProperty("TablePrefix", out var tableprefixProperty) ? tableprefixProperty.GetString()! : "";
+                            string sslMode = root.TryGetProperty("SslMode", out var sslModeProperty) ? sslModeProperty.GetString()! : "Prefered";
 
                             PlayerStatsTable = $"{(tableprefix != "" ? $"PlayerStats_{tableprefix}" : "PlayerStats")}";
 
                             if (dbType.Equals(DatabaseType.MySQL))
                             {
                                 int timeout = root.TryGetProperty("Timeout", out var timeoutProperty) ? timeoutProperty.GetInt32()! : 30;
-                                return $"Server={host};Database={database};User ID={username};Password={password};Port={port};CharSet=utf8mb4;Connection Timeout={timeout};";
+                                return $"Server={host};Database={database};User ID={username};Password={password};Port={port};CharSet=utf8mb4;Connection Timeout={timeout};SslMode={sslMode}";
                             }
                             else if (dbType.Equals(DatabaseType.PostgreSQL))
                             {

--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -166,7 +166,7 @@ namespace SharpTimer
                             string password = root.TryGetProperty("Password", out var passwordProperty) ? passwordProperty.GetString()! : "root";
                             int port = root.TryGetProperty("Port", out var portProperty) ? portProperty.GetInt32()! : 3306;
                             string tableprefix = root.TryGetProperty("TablePrefix", out var tableprefixProperty) ? tableprefixProperty.GetString()! : "";
-                            string sslMode = root.TryGetProperty("SslMode", out var sslModeProperty) ? sslModeProperty.GetString()! : "Prefered";
+                            string sslMode = root.TryGetProperty("SslMode", out var sslModeProperty) ? sslModeProperty.GetString()! : "Preferred";
 
                             PlayerStatsTable = $"{(tableprefix != "" ? $"PlayerStats_{tableprefix}" : "PlayerStats")}";
 


### PR DESCRIPTION
Add `SslMode` option to allow mysql connection using others ssl modes

Available options:
- **Preferred** - Use SSL if the server supports it. (default)
- **None** - Do not use SSL.
- **Required** - Always use SSL. Deny connection if server does not support SSL. Does not validate CA or hostname.
- **VerifyCA** - Always use SSL. Validates the CA but tolerates hostname mismatch.
- **VerifyFull** - Always use SSL. Validates CA and hostname.