### PR TITLE
Add support for configuring replay data dir

### DIFF
--- a/cfg/SharpTimer/config.cfg
+++ b/cfg/SharpTimer/config.cfg
@@ -148,11 +148,11 @@ sharptimer_global_rank_group4_percentile            25                          
 sharptimer_global_rank_group5_percentile            50                                      // The top % of record holders in group no5. Default value : 50
 
 //REPLAYS
-sharptimer_replays_enabled                          false                                   // Whether replays should be enabled or not. This option might be performance taxing and use more ram & cpu. Default value : false
-sharptimer_replay_only_sr                           false                                   // Only saves SR replay if true. Default value: false
-sharptimer_replay_max_length                        300                                     // The maximum length for a Replay to be saved in seconds. Anything longer will be discarded Default value : 300
-sharptimer_replay_bot_enabled						false									// Whether a looping Server Record bot should be spawned in or not (requires navmesh fix). Default value : false
-sharptimer_replay_bot_name							SERVER RECORD REPLAY					// What the name of the Replay Record bot should be. Default value : SERVER RECORD REPLAY
+sharptimer_replays_enabled                          false                                   // Whether replays should be enabled or not. This option might be performance taxing and use more ram & cpu. Default value: false
+sharptimer_replay_max_length                        300                                     // The maximum length for a Replay to be saved in seconds. Anything longer will be discarded Default value: 300
+sharptimer_replay_bot_enabled						false									// Whether a looping Server Record bot should be spawned in or not (requires navmesh fix). Default value: false
+sharptimer_replay_bot_name							SERVER RECORD REPLAY					// What the name of the Replay Record bot should be. Default value: SERVER RECORD REPLAY
+sharptimer_replay_data_directory                    csgo cfg SharpTimer PlayerReplayData         // Directory for replay data. Prepended with game dir. Default value: csgo cfg SharpTimer PlayerReplayData
 
 
 //CHECKPOINTS/SAVELOC

--- a/cfg/SharpTimer/config.cfg
+++ b/cfg/SharpTimer/config.cfg
@@ -152,7 +152,7 @@ sharptimer_replays_enabled                          false                       
 sharptimer_replay_max_length                        300                                     // The maximum length for a Replay to be saved in seconds. Anything longer will be discarded Default value: 300
 sharptimer_replay_bot_enabled						false									// Whether a looping Server Record bot should be spawned in or not (requires navmesh fix). Default value: false
 sharptimer_replay_bot_name							SERVER RECORD REPLAY					// What the name of the Replay Record bot should be. Default value: SERVER RECORD REPLAY
-sharptimer_replay_data_directory                    csgo cfg SharpTimer PlayerReplayData         // Directory for replay data. Prepended with game dir. Default value: csgo cfg SharpTimer PlayerReplayData
+sharptimer_replay_data_directory                    csgo/cfg/SharpTimer/PlayerReplayData         // Directory for replay data. Prepended with game dir. Default value: csgo cfg SharpTimer PlayerReplayData
 
 
 //CHECKPOINTS/SAVELOC

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -1803,5 +1803,20 @@ namespace SharpTimer
 
             remoteSurfDataSource = $"{args}";
         }
+        
+        [ConsoleCommand("sharptimer_replay_data_directory", "Directory for replay data. Prepended with game dir. Default value: csgo cfg SharpTimer PlayerReplayData")]
+        [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
+        public void SharpTimerReplayDataDirectory(CCSPlayerController? player, CommandInfo command)
+        {
+            string args = command.ArgString.Trim();
+            
+            if (string.IsNullOrEmpty(args))
+            {
+                playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData");
+                return;
+            }
+            
+            playerReplaysPath = Path.Join(gameDir, args);
+        }
     }
 }

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -1804,7 +1804,7 @@ namespace SharpTimer
             remoteSurfDataSource = $"{args}";
         }
         
-        [ConsoleCommand("sharptimer_replay_data_directory", "Directory for replay data. Prepended with game dir. Default value: csgo cfg SharpTimer PlayerReplayData")]
+        [ConsoleCommand("sharptimer_replay_data_directory", "Directory for replay data. Prepended with game dir. Default value: csgo/cfg/SharpTimer/PlayerReplayData")]
         [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
         public void SharpTimerReplayDataDirectory(CCSPlayerController? player, CommandInfo command)
         {
@@ -1816,7 +1816,7 @@ namespace SharpTimer
                 return;
             }
             
-            playerReplaysPath = Path.Join(gameDir, args);
+            Path.Join([gameDir, ..args.Split('/')]);
         }
     }
 }

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -1816,7 +1816,7 @@ namespace SharpTimer
                 return;
             }
             
-            Path.Join([gameDir, ..args.Split('/')]);
+            playerReplaysPath = Path.Join([gameDir, ..args.Split('/')]);
         }
     }
 }

--- a/src/Features/ReplayUtils.cs
+++ b/src/Features/ReplayUtils.cs
@@ -181,9 +181,9 @@ namespace SharpTimer
 
                 string fileName = $"{steamID}_replay.json";
                 string playerReplaysDirectory;
-                if (style != 0) playerReplaysDirectory = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style));
-                else playerReplaysDirectory = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}");
-                string playerReplaysPath = Path.Join(playerReplaysDirectory, fileName);
+                if(style != 0) playerReplaysDirectory = Path.Join(this.playerReplaysPath, bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style));
+                else playerReplaysDirectory = Path.Join(this.playerReplaysPath, bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}");
+                string replayFilePath = Path.Join(playerReplaysDirectory, fileName);
 
                 try
                 {
@@ -198,7 +198,7 @@ namespace SharpTimer
                         .Select((frame, index) => new IndexedReplayFrames { Index = index, Frame = frame })
                         .ToList();
 
-                    using (Stream stream = new FileStream(playerReplaysPath, FileMode.Create))
+                    using (Stream stream = new FileStream(replayFilePath, FileMode.Create))
                     {
                         JsonSerializer.Serialize(stream, indexedReplayFrames);
                     }
@@ -239,8 +239,8 @@ namespace SharpTimer
         {
             string fileName = $"{steamId}_replay.json";
             string playerReplaysPath;
-            if (style != 0) playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style), fileName);
-            else playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}", fileName);
+            if(style != 0) playerReplaysPath = Path.Join(this.playerReplaysPath, bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style), fileName);
+            else playerReplaysPath = Path.Join(this.playerReplaysPath, bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}", fileName);
 
             try
             {
@@ -435,8 +435,8 @@ namespace SharpTimer
 
             string fileName = $"{(topSteamID == "x" ? $"{srSteamID}" : $"{topSteamID}")}_replay.json";
             string playerReplaysPath;
-            if (style != 0) playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), GetNamedStyle(style), fileName);
-            else playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), fileName);
+            if(style != 0) playerReplaysPath = Path.Join(this.playerReplaysPath, (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), GetNamedStyle(style), fileName);
+            else playerReplaysPath = Path.Join(this.playerReplaysPath, (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), fileName);
 
             try
             {

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -278,6 +278,7 @@ namespace SharpTimer
         public string? currentMapName;
         public string? currentAddonID;
         public string? defaultServerHostname = ConVar.Find("hostname")?.StringValue;
+        public string? playerReplaysPath;
 
         public bool discordWebhookEnabled = false;
         public string discordWebhookBotName = "SharpTimer";

--- a/src/SharpTimer.cs
+++ b/src/SharpTimer.cs
@@ -42,9 +42,8 @@ namespace SharpTimer
             gameDir = Server.GameDirectory;
             SharpTimerDebug($"Set gameDir to {gameDir}");
 
-            string recordsFileName = $"SharpTimer/PlayerRecords/";
-            playerRecordsPath = Path.Join(gameDir + "/csgo/cfg", recordsFileName);
-
+            const string recordsFileName = "SharpTimer/PlayerRecords/";
+            playerRecordsPath = Path.Join(gameDir, "csgo", "cfg", recordsFileName);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) isLinux = true;
             else isLinux = false;


### PR DESCRIPTION
# Summary
This PR allows server administrators to customize where SharpTimer saves replay files.

## Additions
- Added `sharptimer_replay_data_directory` global, default is `csgo/cfg/SharpTimer/PlayerReplayData` (what the old hardcoded value is)
  - Added convar command for configuration
  - Added default population to config.cfg
- Updated replay logic to use the new value instead of a hardcoded one

## Caveats
I was unable to get replays persistent through Docker with the previous defaults (something about us persisting the base directory / cfg I think). I've confirmed that this new change allows me to persist replays as expected, though I have not been able to verify that default behavior has not regressed.