### PR TITLE
Add scoreboard indicators for basic stats

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -830,8 +830,8 @@ namespace SharpTimer
                 string ranking, rankIcon, mapPlacement, serverPoints = "", serverPlacement = "";
                 bool useGlobalRanks = enableDb && globalRanksEnabled;
 
-                ranking = useGlobalRanks ? await GetPlayerServerPlacement(player, steamId, playerName) : await GetPlayerMapPlacementWithTotal(player, steamId, playerName, false, false, 0, style);
-                rankIcon = useGlobalRanks ? await GetPlayerServerPlacement(player, steamId, playerName, true) : await GetPlayerMapPlacementWithTotal(player, steamId, playerName, true, false, 0, style);
+                ranking      = useGlobalRanks ? await GetPlayerServerPlacement(steamId, playerName) : await GetPlayerMapPlacementWithTotal(player, steamId, playerName, false, false, 0, style);
+                rankIcon     = useGlobalRanks ? await GetPlayerServerPlacement(steamId, playerName, true) : await GetPlayerMapPlacementWithTotal(player, steamId, playerName, true, false, 0, style);
                 mapPlacement = await GetPlayerMapPlacementWithTotal(player, steamId, playerName, false, true, 0, style);
 
                 foreach (var bonusRespawnPose in bonusRespawnPoses)
@@ -857,8 +857,8 @@ namespace SharpTimer
 
                 if (useGlobalRanks)
                 {
-                    serverPoints = await GetPlayerServerPlacement(player, steamId, playerName, false, false, true);
-                    serverPlacement = await GetPlayerServerPlacement(player, steamId, playerName, false, true, false);
+                    serverPoints    = await GetPlayerServerPlacement(steamId, playerName, false, false, true);
+                    serverPlacement = await GetPlayerServerPlacement(steamId, playerName, false, true, false);
                 }
 
                 int pbTicks = enableDb ? await GetPreviousPlayerRecordFromDatabase(steamId, currentMapName!, playerName, 0, style) : await GetPreviousPlayerRecord(steamId, 0);

--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -870,6 +870,7 @@ namespace SharpTimer
                     playerTimers[playerSlot].CachedPB = $"{(pbTicks != 0 ? $" {FormatTime(pbTicks)}" : "")}";
                     playerTimers[playerSlot].CachedRank = ranking;
                     playerTimers[playerSlot].CachedMapPlacement = mapPlacement;
+                    cachedPlacements.Remove(playerSlot);
 
                     if (displayScoreboardTags) AddScoreboardTagToPlayer(player!, ranking);
                 });

--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -2577,18 +2577,13 @@ namespace SharpTimer
             return 0;
         }
 
-        public async Task<int> GetPlayerPointsFromDatabase(CCSPlayerController? player, string steamId, string playerName)
+        public async Task<int> GetPlayerPointsFromDatabase(string steamId, string? playerName = null)
         {
             SharpTimerDebug("Trying GetPlayerPointsFromDatabase");
             int playerPoints = 0;
 
             try
             {
-                if (!IsAllowedClient(player))
-                {
-                    return playerPoints;
-                }
-
                 using (var connection = await OpenConnectionAsync())
                 {
                     await CreatePlayerStatsTableAsync(connection);

--- a/src/Player/PlayerScoreboard.cs
+++ b/src/Player/PlayerScoreboard.cs
@@ -41,7 +41,7 @@ public partial class SharpTimer {
     else
       player.Score = -placement;
 
-    if (stageTriggerCount == 1) { // Linear map, show checkpoints
+    if (stageTriggerCount <= 1) { // Linear map, show checkpoints
       matchStats.Kills = timer.CurrentMapCheckpoint;
     } else {
       matchStats.Kills = timer.IsBonusTimerRunning ?

--- a/src/Player/PlayerScoreboard.cs
+++ b/src/Player/PlayerScoreboard.cs
@@ -1,0 +1,55 @@
+﻿using System.Net;
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Modules.Utils;
+
+namespace SharpTimer;
+
+public partial class SharpTimer {
+  private Dictionary<int, int> cachedPlacements = new();
+
+  public void AssignPlayerScoreboards() {
+    foreach (var player in connectedPlayers.Values.Where(player
+      => player.IsValid))
+      assignScoreboard(player);
+  }
+
+  private void assignScoreboard(CCSPlayerController player) {
+    if (player.Team <= CsTeam.Spectator || player.ActionTrackingServices == null
+      || player.IsBot)
+      return;
+    var slot = player.Slot;
+
+    if (!playerTimers.TryGetValue(slot, out var timer)) return;
+
+    if (timer.IsAddingStartZone || timer.IsAddingEndZone
+      || timer.IsAddingBonusStartZone || timer.IsAddingBonusEndZone)
+      return;
+
+    if (timer is { IsTimerRunning: false, IsBonusTimerRunning: false }) return;
+
+    var ticks = timer.TimerTicks;
+    var span  = TimeSpan.FromSeconds(ticks / 64.0);
+
+    var seconds = span.Seconds;
+    var minutes = span.Minutes;
+
+    player.ActionTrackingServices.MatchStats.Assists = seconds;
+    player.ActionTrackingServices.MatchStats.Deaths  = minutes;
+
+    if (!cachedPlacements.TryGetValue(slot, out var placement))
+      fetchPlayerPlacement(slot, player.SteamID.ToString());
+    else
+      player.Score = -placement;
+
+    Utilities.SetStateChanged(player, "CCSPlayerController",
+      "m_pActionTrackingService");
+  }
+
+  private void fetchPlayerPlacement(int slot, string steamId) {
+    Task.Run(async () => {
+      var rank = (await GetPlayerServerRank(steamId)).Item1;
+      cachedPlacements[slot] = rank;
+    });
+  }
+}

--- a/src/SharpTimer.cs
+++ b/src/SharpTimer.cs
@@ -19,6 +19,7 @@ using CounterStrikeSharp.API.Core.Attributes;
 using CounterStrikeSharp.API.Modules.Cvars;
 using CounterStrikeSharp.API.Modules.Memory.DynamicFunctions;
 using System.Runtime.InteropServices;
+using CounterStrikeSharp.API.Modules.Timers;
 
 namespace SharpTimer
 {
@@ -363,6 +364,8 @@ namespace SharpTimer
             {
                 DamageHook();
             });
+
+            AddTimer(1.0f, AssignPlayerScoreboards, TimerFlags.REPEAT);
 
             AddCommandListener("say", OnPlayerChat);
             AddCommandListener("say_team", OnPlayerChat);


### PR DESCRIPTION
# Summary
This PR adds a quick-glance representation to players about times and placements. Specifically:

This is my personal preferred implementation, but support for configuration could be added on.

## Description
- The Kills represent what the player is currently attempting
  - For Linear records, this is the player's current checkpoint
  - If attempting bonuses, this is negative to indicate such (e.g. attempting Bonus 1 would set it to -1)
- The Deaths and Assists together represent the player's current time, with the Deaths being minutes (0 and up), and assists being seconds [0, 59]
- The Score is the player's total _server_ rank, with the sign flipped (this way, higher ranked players are ranked higher on the scoreboard).
  - Conveniently this places any replay bots (with 0 score) at the top.

## Example
![scoreboard](https://img.msws.xyz/img/b3014d8d3eaf7796.png)

In the example screenshot I am on Stage 6, one minute and 21 seconds in, and am ranked #1 on the server overall.

## Review Notes
I've [modified some Database-related code](https://github.com/Letaryat/poor-sharptimer/pull/120/files#diff-dcbde852e98227acd86d141521f588b392ab20b65782e1b4962f09cac770ed73L2587) due to it using Natives Asynchronously. The removed guard checks were (from my basic understanding) unnecessary, but further review is strongly recommended prior to merging.