### PR TITLE
Allow configuring !rs behavior on linear maps

### DIFF
--- a/cfg/SharpTimer/config.cfg
+++ b/cfg/SharpTimer/config.cfg
@@ -110,7 +110,7 @@ sharptimer_rank_enabled                             true                        
 sharptimer_goto_enabled                             false                                   // Whether !goto is enabled by default or not. Default value : false
 sharptimer_help_enabled                             true                                    // Whether !help is enabled by default or not. Default value : true
 sharptimer_enable_noclip                            false                                   // Whether !noclip/!nc is enabled by default or not. Default value : false
-
+sharptimer_rs_enabled_onlinear                      false                                   // Whether !rs will reset players on linear maps. Default value : false
 
 //GLOBAL RANK POINTS
 sharptimer_global_rank_points_enabled               false                                   // Whether the plugin should reward players with global points for completing maps. MySQL Requierd. Default value : false

--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -1565,6 +1565,10 @@ namespace SharpTimer
 
             if (stageTriggerCount == 0)
             {
+                if (enableRsOnLinear) {
+                    player.ExecuteClientCommandFromServer("css_r");
+                    return;
+                }
                 PrintToChat(player, Localizer["map_no_stages"]);
                 return;
             }

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -1528,6 +1528,15 @@ namespace SharpTimer
 
             enableNoclip = bool.TryParse(args, out bool enableNoclipValue) ? enableNoclipValue : args != "0" && enableNoclip;
         }
+        
+        [ConsoleCommand("sharptimer_rs_enabled_onlinear", "Whether !rs will reset players on linear maps. Default value : false")]
+        [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
+        public void SharpTimerResetLinearMapsConvar(CCSPlayerController? player, CommandInfo command)
+        {
+            string args = command.ArgString;
+
+            enableRsOnLinear = bool.TryParse(args, out bool enableRsOnLinearValue) ? enableRsOnLinearValue : args != "0" && enableRsOnLinear;
+        }
 
         [ConsoleCommand("sharptimer_styles_enabled", "Enable or disable styles. Default value: true")]
         [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -190,6 +190,7 @@ namespace SharpTimer
         public bool startzoneJumping = true;
         public bool spawnOnRespawnPos = false;
         public bool enableNoclip = false;
+        public bool enableRsOnLinear = false;
 
         public bool enableStyles = true;
         public bool enableStylePoints = true;


### PR DESCRIPTION
# Summary
This PR allows the `css_rs` command to behave as `css_r` on linear maps.

## Motive
A player noted that they typically bind `rs` to a key to allow for easy restarts, but they'd prefer to only have to use one single key to restart (either the entire map for linears, or the stage for staged) rather than having two distinct buttons.

## Description
This PR adds a configurable `sharptimer_rs_enabled_onlinear` option (default to false, which is the behavior prior to this PR) to allow the `rs` command to reset you on linear maps, instead of printing an error message.