### PR TITLE
Add support for binary formatting of replay data

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -306,8 +306,12 @@ namespace SharpTimer
 
             if (wr)
                 await ReadReplayFromGlobal(player, wrID, style, bonusX);
-            else
-                await ReadReplayFromJson(player, !self ? srSteamID : pbSteamID, playerSlot, bonusX, style);
+            else {
+                if (useBinaryReplays)
+                    await ReadReplayFromBinary(player, !self ? srSteamID : pbSteamID, playerSlot, bonusX, style);
+                else
+                    await ReadReplayFromJson(player, !self ? srSteamID : pbSteamID, playerSlot, bonusX, style);
+            }
 
             if (playerReplays[playerSlot].replayFrames.Count == 0) return;
 

--- a/src/Commands/ConfigConvars.cs
+++ b/src/Commands/ConfigConvars.cs
@@ -1803,5 +1803,14 @@ namespace SharpTimer
 
             remoteSurfDataSource = $"{args}";
         }
+        
+        [ConsoleCommand("sharptimer_replays_use_binary", "Save replays as binary files instead of json. Default value: false")]
+        [CommandHelper(whoCanExecute: CommandUsage.SERVER_ONLY)]
+        public void SharpTimerReplaysUseBinary(CCSPlayerController? player, CommandInfo command)
+        {
+            string args = command.ArgString;
+
+            useBinaryReplays = bool.TryParse(args, out bool useBinaryReplaysValue) ? useBinaryReplaysValue : args != "0" && useBinaryReplays;
+        }
     }
 }

--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -668,7 +668,12 @@ namespace SharpTimer
                             dBFormattedTime = formattedTime;
                             playerPoints = timerTicks;
                             beatPB = true;
-                            if (enableReplays && !onlySRReplay) _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            if (enableReplays && !onlySRReplay) {
+                                if(useBinaryReplays)
+                                    _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                                else
+                                    _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            }
                         }
                         else
                         {
@@ -762,7 +767,13 @@ namespace SharpTimer
                             if (enableDb && IsAllowedPlayer(player)) await RankCommandHandler(player, steamId, playerSlot, playerName, true, style);
                             if (globalRanksEnabled == true) await SavePlayerPoints(steamId, playerName, playerSlot, timerTicks, dBtimerTicks, beatPB, bonusX, style, dBtimesFinished);
                             if (IsAllowedPlayer(player)) Server.NextFrame(() => _ = Task.Run(async () => await PrintMapTimeToChat(player!, steamId, playerName, dBtimerTicks, timerTicks, bonusX, dBtimesFinished, style, prevSR)));
-                            if (enableReplays && onlySRReplay && prevSR > timerTicks) _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            if (enableReplays && onlySRReplay
+                                && prevSR > timerTicks) {
+                                if(useBinaryReplays)
+                                    _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                                else
+                                    _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            }
                     
                             Server.NextFrame(async () =>
                             {
@@ -828,7 +839,12 @@ namespace SharpTimer
                     else
                     {
                         Server.NextFrame(() => SharpTimerDebug($"No player record yet"));
-                        if (enableReplays && !onlySRReplay) _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                        if (enableReplays && !onlySRReplay) {
+                            if (useBinaryReplays)
+                                _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            else
+                                _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                        }
                         await row.CloseAsync();
 
                         string? upsertQuery;
@@ -872,7 +888,13 @@ namespace SharpTimer
                             Server.NextFrame(() => SharpTimerDebug($"Saved player {(bonusX != 0 ? $"bonus {bonusX} time" : "time")} to database for {playerName} {timerTicks} {DateTimeOffset.UtcNow.ToUnixTimeSeconds()}"));
                             if (IsAllowedPlayer(player)) await RankCommandHandler(player, steamId, playerSlot, playerName, true, style);
                             if (IsAllowedPlayer(player)) Server.NextFrame(() => _ = Task.Run(async () => await PrintMapTimeToChat(player!, steamId, playerName, dBtimerTicks, timerTicks, bonusX, 1, style, prevSR)));
-                            if (enableReplays && onlySRReplay && prevSR > timerTicks) _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            if (enableReplays && onlySRReplay
+                                && prevSR > timerTicks) {
+                                if (useBinaryReplays)
+                                    _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                                else
+                                    _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[playerSlot].currentStyle));
+                            }
                             
                             Server.NextFrame(async () =>
                             {

--- a/src/Features/ReplayUtils.cs
+++ b/src/Features/ReplayUtils.cs
@@ -213,7 +213,6 @@ namespace SharpTimer
 
         public async Task DumpReplayToBinary(CCSPlayerController player, string steamID, int playerSlot, int bonusX = 0, int style = 0)
         {
-            _ = DumpReplayToJson(player, steamID, playerSlot, bonusX, style);
             await Task.Run(() =>
             {
                 if (!IsAllowedPlayer(player))
@@ -224,15 +223,9 @@ namespace SharpTimer
 
                 string fileName = $"{steamID}_replay.dat";
                 string playerReplaysDirectory;
-<<<<<<< Updated upstream
                 if (style != 0) playerReplaysDirectory = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style));
                 else playerReplaysDirectory = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}");
                 string playerReplaysPath = Path.Join(playerReplaysDirectory, fileName);
-=======
-                if(style != 0) playerReplaysDirectory = Path.Join(this.playerReplaysPath, bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style));
-                else playerReplaysDirectory = Path.Join(this.playerReplaysPath, bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}");
-                string replayFilePath = Path.Join(playerReplaysDirectory, fileName);
->>>>>>> Stashed changes
 
                 try
                 {

--- a/src/Features/ReplayUtils.cs
+++ b/src/Features/ReplayUtils.cs
@@ -213,6 +213,7 @@ namespace SharpTimer
 
         public async Task DumpReplayToBinary(CCSPlayerController player, string steamID, int playerSlot, int bonusX = 0, int style = 0)
         {
+            _ = DumpReplayToJson(player, steamID, playerSlot, bonusX, style);
             await Task.Run(() =>
             {
                 if (!IsAllowedPlayer(player))
@@ -221,11 +222,17 @@ namespace SharpTimer
                     return;
                 }
 
-                string fileName = $"{steamID}_replay.json";
+                string fileName = $"{steamID}_replay.dat";
                 string playerReplaysDirectory;
+<<<<<<< Updated upstream
                 if (style != 0) playerReplaysDirectory = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style));
                 else playerReplaysDirectory = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}");
                 string playerReplaysPath = Path.Join(playerReplaysDirectory, fileName);
+=======
+                if(style != 0) playerReplaysDirectory = Path.Join(this.playerReplaysPath, bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style));
+                else playerReplaysDirectory = Path.Join(this.playerReplaysPath, bonusX == 0 ? $"{currentMapName}" : $"{currentMapName}_bonus{bonusX}");
+                string replayFilePath = Path.Join(playerReplaysDirectory, fileName);
+>>>>>>> Stashed changes
 
                 try
                 {
@@ -240,7 +247,7 @@ namespace SharpTimer
                         .Select((frame, index) => new IndexedReplayFrames { Index = index, Frame = frame })
                         .ToList();
 
-                    using Stream stream = new FileStream(playerReplaysPath, FileMode.Create);
+                    using Stream stream = new FileStream(replayFilePath, FileMode.Create);
                     BinaryWriter writer = new BinaryWriter(stream);
                     
                     writer.Write(REPLAY_VERSION);
@@ -295,6 +302,7 @@ namespace SharpTimer
 
         private async Task ReadReplayFromJson(CCSPlayerController player, string steamId, int playerSlot, int bonusX = 0, int style = 0)
         {
+            SharpTimerDebug($"Reading replay from JSON");
             string fileName = $"{steamId}_replay.json";
             string playerReplaysPath;
             if (style != 0) playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style), fileName);
@@ -304,6 +312,7 @@ namespace SharpTimer
             {
                 if (File.Exists(playerReplaysPath))
                 {
+                    SharpTimerDebug($"Path: {playerReplaysPath}, creating stream");
                     var jsonString = await File.ReadAllTextAsync(playerReplaysPath);
                     if (!jsonString.Contains("PositionString"))
                     {
@@ -339,11 +348,13 @@ namespace SharpTimer
             catch (Exception ex)
             {
                 SharpTimerError($"Error during deserialization: {ex.Message}");
+                SharpTimerError($"Error during deserialization: {ex.StackTrace}");
             }
         }
         
         private async Task ReadReplayFromBinary(CCSPlayerController player, string steamId, int playerSlot, int bonusX = 0, int style = 0)
         {
+            SharpTimerDebug($"Reading replay from Binary");
             string fileName = $"{steamId}_replay.dat";
             string playerReplaysPath;
             if (style != 0) playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}", GetNamedStyle(style), fileName);
@@ -358,6 +369,8 @@ namespace SharpTimer
                     return;
                 }
                 
+                SharpTimerDebug($"Path: {playerReplaysPath}, creating stream");
+                
                 using Stream stream = new FileStream(playerReplaysPath, FileMode.Open);
                 BinaryReader reader = new BinaryReader(stream);
                 
@@ -371,25 +384,27 @@ namespace SharpTimer
                    
                 var replayFrames = new List<PlayerReplays.ReplayFrames>();
                 
-                while (reader.BaseStream.Position != reader.BaseStream.Length)
-                {
-                    var position = new Vector(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-                    var rotation = new QAngle(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-                    var speed = new Vector(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
-                    var buttons = (PlayerButtons)reader.ReadInt32();
-                    var flags = (uint)reader.ReadInt32();
-                    var moveType = (MoveType_t)reader.ReadInt32();
-                    
-                    replayFrames.Add(new PlayerReplays.ReplayFrames
+                await Server.NextFrameAsync(() => {
+                    while (reader.BaseStream.Position != reader.BaseStream.Length)
                     {
-                        Position = ReplayVector.GetVectorish(position),
-                        Rotation = ReplayQAngle.GetQAngleish(rotation),
-                        Speed = ReplayVector.GetVectorish(speed),
-                        Buttons = buttons,
-                        Flags = flags,
-                        MoveType = moveType
-                    });
-                }
+                            var position = new Vector(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+                            var rotation = new QAngle(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+                            var speed = new Vector(reader.ReadSingle(), reader.ReadSingle(), reader.ReadSingle());
+                            var buttons = (PlayerButtons)reader.ReadInt32();
+                            var flags = (uint)reader.ReadInt32();
+                            var moveType = (MoveType_t)reader.ReadInt32();
+                        
+                            replayFrames.Add(new PlayerReplays.ReplayFrames
+                            {
+                                Position = ReplayVector.GetVectorish(position),
+                                Rotation = ReplayQAngle.GetQAngleish(rotation),
+                                Speed    = ReplayVector.GetVectorish(speed),
+                                Buttons  = buttons,
+                                Flags    = flags,
+                                MoveType = moveType
+                            });
+                    }
+                });
                 
                 if (!playerReplays.TryGetValue(playerSlot, out PlayerReplays? value))
                 {
@@ -402,6 +417,7 @@ namespace SharpTimer
             catch (Exception ex)
             {
                 SharpTimerError($"Error during deserialization: {ex.Message}");
+                SharpTimerError($"Error during deserialization: {ex.StackTrace}");
             }
         }
 

--- a/src/Features/ReplayUtils.cs
+++ b/src/Features/ReplayUtils.cs
@@ -240,7 +240,7 @@ namespace SharpTimer
                         .Select((frame, index) => new IndexedReplayFrames { Index = index, Frame = frame })
                         .ToList();
 
-                    using Stream stream = new FileStream(replayFilePath, FileMode.Create);
+                    using Stream stream = new FileStream(playerReplaysPath, FileMode.Create);
                     BinaryWriter writer = new BinaryWriter(stream);
                     
                     writer.Write(REPLAY_VERSION);
@@ -563,7 +563,8 @@ namespace SharpTimer
 
             if ((srSteamID == "null" || srPlayerName == "null" || srTime == "null") && topSteamID != "x") return false;
 
-            string fileName = $"{(topSteamID == "x" ? $"{srSteamID}" : $"{topSteamID}")}_replay.json";
+            string ext = useBinaryReplays ? "dat" : "json";
+            string fileName = $"{(topSteamID == "x" ? $"{srSteamID}" : $"{topSteamID}")}_replay.{ext}";
             string playerReplaysPath;
             if (style != 0) playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), GetNamedStyle(style), fileName);
             else playerReplaysPath = Path.Join(gameDir, "csgo", "cfg", "SharpTimer", "PlayerReplayData", (bonusX == 0 ? currentMapName : $"{currentMapName}_bonus{bonusX}"), fileName);

--- a/src/Features/ReplayUtils.cs
+++ b/src/Features/ReplayUtils.cs
@@ -571,8 +571,13 @@ namespace SharpTimer
 
             try
             {
-                if (File.Exists(playerReplaysPath))
-                {
+                if (File.Exists(playerReplaysPath)) {
+                    if (useBinaryReplays) {
+                        var reader = new BinaryReader(File.Open(playerReplaysPath, FileMode.Open));
+                        var version = reader.ReadInt32();
+                        
+                        return version == REPLAY_VERSION;
+                    }
                     var jsonString = await File.ReadAllTextAsync(playerReplaysPath);
                     if (!jsonString.Contains("PositionString"))
                     {

--- a/src/Player/PlayerTimers.cs
+++ b/src/Player/PlayerTimers.cs
@@ -200,7 +200,12 @@ namespace SharpTimer
                             File.WriteAllText(mapRecordsPath, updatedJson);
 
                             if ((stageTriggerCount != 0 || cpTriggerCount != 0) && bonusX == 0 && (!enableDb) && playerTimers[player.Slot].currentStyle == 0) _ = Task.Run(async () => await DumpPlayerStageTimesToJson(player, steamId, playerSlot));
-                            if (enableReplays == true && !enableDb) _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[player.Slot].currentStyle));
+                            if (enableReplays == true && !enableDb) {
+                                if (useBinaryReplays)
+                                    _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, playerSlot, bonusX, playerTimers[player.Slot].currentStyle));
+                                else
+                                    _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, playerSlot, bonusX, playerTimers[player.Slot].currentStyle));
+                            }
                         }
                         else
                         {

--- a/src/Plugin/Classes.cs
+++ b/src/Plugin/Classes.cs
@@ -300,6 +300,7 @@ namespace SharpTimer
         public int BonusX { get; set; }
         public int Style { get; set; }
         public List<ReplayFrames> replayFrames { get; set; } = [];
+        [Serializable]
         public class ReplayFrames
         {
             public ReplayVector? Position { get; set; }
@@ -311,6 +312,7 @@ namespace SharpTimer
         }
     }
 
+    [Serializable]
     public class IndexedReplayFrames
     {
         public int Index { get; set; }

--- a/src/Plugin/Globals.cs
+++ b/src/Plugin/Globals.cs
@@ -118,6 +118,7 @@ namespace SharpTimer
         public bool enableStageTimes = true;
         public bool ignoreJSON = false;
         public bool enableReplays = false;
+        public bool useBinaryReplays = false;
         public bool onlySRReplay = false;
         public bool enableSRreplayBot = false;
         public bool startKickingAllFuckingBotsExceptReplayOneIFuckingHateValveDogshitFuckingCompanySmile = false;

--- a/src/SharpTimer.cs
+++ b/src/SharpTimer.cs
@@ -31,6 +31,9 @@ namespace SharpTimer
         private int movementServices;
         private int movementPtr;
         private readonly CSPlayerState[] _oldPlayerState = new CSPlayerState[65];
+
+        public const int REPLAY_VERSION = 1;
+        
         public override void Load(bool hotReload)
         {
             SharpTimerConPrint("Loading Plugin...");


### PR DESCRIPTION
# Summary
Currently replay data uses the JSON encoding scheme, which can be rather inefficient due to the many duplicate keys.

This PR adds an option to allow server administrators to locally save replays as raw `.dat` files, instead of `.json` files.
Simple testing has been done and confirmed to recreate the current replay system with ~20% of the space needed compared to the JSON representation.

### Notes
- Replay data does not store frame indicies
- Replay data is versioned, current version is 1 (should up this anytime we change the format for replays)
- No support for converting from JSON <-> DAT is implemented, but may be by other developers

## Changes
- Adds `sharptimer_replays_use_binary` as a config command, defaults to false (uses JSON by default
- A few added debug messages