### PR TITLE
Fix stage verification

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -143,7 +143,7 @@
 
   //Error
   "error_savingtime": "Error Saving Time: Player time is 0 ticks",
-  "error_stagenotmatchfinalone": "Error Saving Time: Player current stage does not match final one{0}",
+  "error_stagenotmatchfinalone": "Error Saving Time: Player current stage does not match final one",
   "error_checkpointnotmatchfinalone": "Error Saving Time: Player current checkpoint does not match final one{0}",
   
   //help console Localizer

--- a/lang/fi.json
+++ b/lang/fi.json
@@ -104,7 +104,7 @@
 	
 	// Error
 	"error_savingtime": "Virhe tallentaessa aikaa: Pelaajan aika on 0 tikkiä",
-	"error_stagenotmatchfinalone": "Virhe tallentaessa aikaa: Pelaajan nykyinen vaihe ei vastaa viimeistä vaihetta {0}",
+	"error_stagenotmatchfinalone": "Virhe tallentaessa aikaa: Pelaajan nykyinen vaihe ei vastaa viimeistä vaihetta",
 	"error_checkpointnotmatchfinalone": "Virhe tallentaessa aikaa: Pelaajan nykyinen tarkistuskohta ei vastaa viimeistä tarkistuspistettä {0}",
 
 	// help console Localizer

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -111,7 +111,7 @@
   
     // Error
   "error_savingtime": "Erreur de sauvegarde du temps : Le temps du joueur est de 0 ticks",
-  "error_stagenotmatchfinalone": "Erreur de sauvegarde du temps : Le niveau actuel du joueur ne correspond pas au dernier niveau {0}",
+  "error_stagenotmatchfinalone": "Erreur de sauvegarde du temps : Le niveau actuel du joueur ne correspond pas au dernier niveau",
   "error_checkpointnotmatchfinalone": "Erreur de sauvegarde du temps : Le point de contrôle actuel du joueur ne correspond pas au dernier point de contrôle {0}",
 
   // help console Localizer

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -142,7 +142,7 @@
 
   // 오류
   "error_savingtime": "시간 저장 오류: 플레이어 시간이 0 틱입니다",
-  "error_stagenotmatchfinalone": "시간 저장 오류: 플레이어의 현재 스테이지가 마지막 스테이지와 일치하지 않습니다{0}",
+  "error_stagenotmatchfinalone": "시간 저장 오류: 플레이어의 현재 스테이지가 마지막 스테이지와 일치하지 않습니다",
   "error_checkpointnotmatchfinalone": "시간 저장 오류: 플레이어의 현재 체크포인트가 마지막 체크포인트와 일치하지 않습니다{0}",
   
   // 도움말 콘솔 지역화

--- a/lang/nb.json
+++ b/lang/nb.json
@@ -135,7 +135,7 @@
 	
 	  // Error
   "error_savingtime": "Feil ved lagring av tid: Spillerens tid er 0 ticks",
-  "error_stagenotmatchfinalone": "Feil ved lagring av tid: Spillerens nåværende nivå stemmer ikke overens med siste nivå {0}",
+  "error_stagenotmatchfinalone": "Feil ved lagring av tid: Spillerens nåværende nivå stemmer ikke overens med siste nivå",
   "error_checkpointnotmatchfinalone": "Feil ved lagring av tid: Spillerens nåværende sjekkpunkt stemmer ikke overens med siste sjekkpunkt {0}",
 
   // help console Localizer

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -111,7 +111,7 @@
   
     // Error
   "error_savingtime": "Błąd zapisywania czasu: Czas gracza wynosi 0 ticks",
-  "error_stagenotmatchfinalone": "Błąd zapisywania czasu: Aktualny etap gracza nie pasuje do ostatniego {0}",
+  "error_stagenotmatchfinalone": "Błąd zapisywania czasu: Aktualny etap gracza nie pasuje do ostatniego",
   "error_checkpointnotmatchfinalone": "Błąd zapisywania czasu: Aktualny punkt kontrolny gracza nie pasuje do ostatniego {0}",
 
   // help console Localizer

--- a/lang/sk.json
+++ b/lang/sk.json
@@ -104,7 +104,7 @@
 	
 	  // Error
   "error_savingtime": "Napaka pri shranjevanju časa: Čas igralca je 0 tics",
-  "error_stagenotmatchfinalone": "Napaka pri shranjevanju časa: Trenutna stopnja igralca se ne ujema z zadnjo {0}",
+  "error_stagenotmatchfinalone": "Napaka pri shranjevanju časa: Trenutna stopnja igralca se ne ujema z zadnjo",
   "error_checkpointnotmatchfinalone": "Napaka pri shranjevanju časa: Trenutna kontrolna točka igralca se ne ujema z zadnjo {0}",
 
   // help console Localizer

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -111,7 +111,7 @@
   
     // Error
   "error_savingtime": "Chyba pri ukladaní času: Čas hráča je 0 tics",
-  "error_stagenotmatchfinalone": "Chyba pri ukladaní času: Aktuálna fáza hráča sa nezhoduje s konečnou {0}",
+  "error_stagenotmatchfinalone": "Chyba pri ukladaní času: Aktuálna fáza hráča sa nezhoduje s konečnou",
   "error_checkpointnotmatchfinalone": "Chyba pri ukladaní času: Aktuálna kontrolná bodka hráča sa nezhoduje s konečnou {0}",
 
   // help console Localizer

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -141,7 +141,7 @@
   
     //Hata
     "error_savingtime": "Zaman kaydedilirken hata: Oyuncu zamanı 0 tick",
-    "error_stagenotmatchfinalone": "Zaman kaydedilirken hata: Oyuncunun geçerli stage'i son stage ile uyuşmuyor{0}",
+    "error_stagenotmatchfinalone": "Zaman kaydedilirken hata: Oyuncunun geçerli stage'i son stage ile uyuşmuyor",
     "error_checkpointnotmatchfinalone": "Zaman kaydedilirken hata: Oyuncunun geçerli kontrol noktası son kontrol noktası ile uyuşmuyor{0}",
     
     //Yardım konsolu Yerelleştirici

--- a/lang/zh-Hans.json
+++ b/lang/zh-Hans.json
@@ -115,7 +115,7 @@
   
   //报错
   "error_savingtime": "保存时间错误：玩家时间为 0 ticks",
-  "error_stagenotmatchfinalone": "保存时间错误：玩家当前阶段与最终阶段不匹配{0}",
+  "error_stagenotmatchfinalone": "保存时间错误：玩家当前阶段与最终阶段不匹配",
   "error_checkpointnotmatchfinalone": "保存时间错误：玩家当前检查点与最终检查点不匹配{0}",
 
   //控制台项

--- a/src/Player/PlayerTimers.cs
+++ b/src/Player/PlayerTimers.cs
@@ -95,10 +95,10 @@ namespace SharpTimer
 
             if (useStageTriggers == true && useCheckpointTriggers == false)
             {
-                if (playerTimer.CurrentMapStage != stageTriggerCount && currentMapOverrideStageRequirement == true)
+                if (playerTimer.CurrentMapStage != stageTriggerCount && currentMapOverrideStageRequirement == false)
                 {
-                    PrintToChat(player, $"{ChatColors.LightRed}{Localizer["error_stagenotmatchfinalone"]}({stageTriggerCount})");
-                    SharpTimerDebug($"Player current stage: {playerTimers[playerSlot].CurrentMapStage}; Final checkpoint: {stageTriggerCount}");
+                    PrintToChat(player, $"{ChatColors.LightRed}{Localizer["error_stagenotmatchfinalone"]} ({playerTimer.CurrentMapStage}/{stageTriggerCount})");
+                    SharpTimerDebug($"Player {player.PlayerName} ({player.SteamID}) tried to finish a map with a current stage of {playerTimer.CurrentMapStage}, but this map has {stageTriggerCount} stages. It is recommended that you review {Server.MapName} for exploits.");
                     playerTimer.IsTimerRunning = false;
                     playerTimer.IsRecordingReplay = false;
                     return;


### PR DESCRIPTION
Changed `currentMapOverrideStageRequirement == true` to `currentMapOverrideStageRequirement == false` in **OnTimerStop**.

currentMapOverrideStageRequirement is globally set to false unless overridden in a map json, so this condition was never being met, hence stage verification not working. I've updated the logging/localization for it as well. I've locally tested it to be working now.