### PR TITLE
Force respawn player when changing styles

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -1378,6 +1378,7 @@ namespace SharpTimer
                         PrintToChat(player, Localizer["style_not_found", desiredStyleInt]);
                         break;
                 }
+                RespawnPlayer(player);
             }
             else
             {
@@ -1454,6 +1455,7 @@ namespace SharpTimer
                         PrintToChat(player, Localizer["style_not_found", styleLowerCase]);
                         break;
                 }
+                RespawnPlayer(player);
             }
         }
 


### PR DESCRIPTION
Partially addresses an exploit where players would use certain styles (like ff) to get high above the start zone to gain extra start speed before switching back to normal. This forces a respawn when using the style command.