### PR TITLE
Fix: css_top blocking main thread & HUD panel always showing [Unranked]

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -671,6 +671,15 @@ namespace SharpTimer
 
             var sortedRecords = await GetSortedRecordsFromDatabase(10, bonusX, mapName, style);
 
+            bool[] replayResults = new bool[sortedRecords.Count];
+            if (enableReplays)
+            {
+                var replayTasks = sortedRecords.Take(10)
+                    .Select(kvp => CheckSRReplay(kvp.Value.SteamID!, bonusX))
+                    .ToArray();
+                replayResults = await Task.WhenAll(replayTasks);
+            }
+
             Server.NextFrame(() =>
             {
                 if (!IsPlayerOrSpectator(player))
@@ -693,20 +702,20 @@ namespace SharpTimer
                     printStatements = [$" {Localizer["top10_records", GetNamedStyle(style), currentMapNamee]}"];
 
                 int rank = 1;
+                int replayIdx = 0;
 
                 foreach (var kvp in sortedRecords.Take(10))
                 {
                     string _playerName = kvp.Value.PlayerName!;
                     int timerTicks = kvp.Value.TimerTicks;
 
-                    bool showReplays = false;
-                    if (enableReplays == true)
-                        showReplays = Task.Run(() => CheckSRReplay(kvp.Value.SteamID!, bonusX)).Result;
-
-                    string replayIndicator = enableReplays ? (showReplays ? $"{ChatColors.Red}◉" : "") : "";
+                    string replayIndicator = "";
+                    if (enableReplays)
+                        replayIndicator = replayResults.Length > replayIdx && replayResults[replayIdx] ? $"{ChatColors.Red}◉" : "";
 
                     printStatements.Add($" {Localizer["records_map", rank, _playerName, replayIndicator, Utils.FormatTime(timerTicks)]}");
                     rank++;
+                    replayIdx++;
                 }
 
                 foreach (var statement in printStatements)

--- a/src/Player/PlayerOnTick.cs
+++ b/src/Player/PlayerOnTick.cs
@@ -385,17 +385,18 @@ namespace SharpTimer
 
         private string GetMainMapInfoLine(PlayerTimerInfo playerTimer)
         {
+            string rankLabel = !string.IsNullOrEmpty(playerTimer.CachedRank) ? playerTimer.CachedRank! : (playerTimer.CachedMapPlacement ?? "");
             return !playerTimer.IsReplaying
                 ? $"<font class='fontSize-s stratum-bold-italic' color='gray'>" +
 
                     $"{playerTimer.CachedPB} " +
-                    $"({playerTimer.CachedMapPlacement})" +
-                    $"{(RankIconsEnabled ? $" |</font> <img src='{playerTimer.RankHUDIcon}'><font class='fontSize-s stratum-bold-italic' color='gray'>" : "")}" +
-                    $"{(enableStyles ? $" | {GetNamedStyle(playerTimer.currentStyle)}" : "")}" +
-                    $"{((MapTierHudEnabled && currentMapTier != null) ? $" | Tier: {currentMapTier}" : "")}" +
-                    $"{((MapTypeHudEnabled && currentMapType != null) ? $" | {currentMapType}" : "")}" +
-                    $"{((MapNameHudEnabled && currentMapType == null && currentMapTier == null) ? $" | {currentMapName}" : "")}" +
-                    $"</font>"
+                    $"{rankLabel}" +
+                    $"{(RankIconsEnabled ? " |</font> <img src='" + playerTimer.RankHUDIcon + "'><font class='fontSize-s stratum-bold-italic' color='gray'>" : "")}" +
+                    $"{(enableStyles ? " | " + GetNamedStyle(playerTimer.currentStyle) : "")}" +
+                    $"{((MapTierHudEnabled && currentMapTier != null) ? " | " + currentMapTier : "")}" +
+                    $"{((MapTypeHudEnabled && currentMapType != null) ? " | " + currentMapType : "")}" +
+                    $"{((MapNameHudEnabled && currentMapType == null && currentMapTier == null) ? " | " + currentMapName : "")}" +
+                    "</font>"
 
                 : $" <font class='fontSize-s stratum-bold-italic' color='gray'>{playerTimer.ReplayHUDString}</font>";
         }


### PR DESCRIPTION
- Fixed an issue where the `css_top` command was causing lag by blocking the main thread. Replaced with asynchronous task execution to improve performance.
- Fixed a bug where the HUD panel always displayed "Unranked", regardless of the player's rank status.
