### PR TITLE
Update Plugin.cs

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -427,7 +427,7 @@ namespace SharpTimer
 
             playerTimers[slot].HideChatSpeed = !playerTimers[slot].HideChatSpeed;
 
-            if (!playerTimers[slot].HideChatSpeed)
+            if (playerTimers[slot].HideChatSpeed)
                 Utils.PrintToChat(player, Localizer["printtime_hidden"]);
             else
                 Utils.PrintToChat(player, Localizer["printtime_shown"]);

--- a/src/Player/PlayerUtils.cs
+++ b/src/Player/PlayerUtils.cs
@@ -202,7 +202,10 @@ namespace SharpTimer
         {
             int startSpeed = int.Parse(GetCurrentPlayerSpeed(player));
             int printSpeed = (maxStartingSpeedEnabled && startSpeed > maxStartingSpeed) ? maxStartingSpeed : startSpeed;
-            Utils.PrintToChat(player, $"{Localizer["prefix"]} {Localizer["start_speed"]} {ChatColors.Olive}{printSpeed}");
+            if (!playerTimers[player.Slot].HideChatSpeed)
+            {
+                Utils.PrintToChat(player, $"{Localizer["start_speed"]} {ChatColors.Olive}{printSpeed}");
+            }
             Utils.PrintToSpec(player, $"{Localizer["start_speed"]} {ChatColors.Olive}{printSpeed}");
         }
       

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -129,7 +129,7 @@ public partial class SharpTimer
                     Utils.LogError("StripperCS2 detected for current map; disabling globalapi");
                 }
                 
-                if (!Directory.Exists($"{gameDir}/csgo/addons/stfixes-metamod/"))
+                if (!File.Exists($"{gameDir}/csgo/addons/metamod/stfixes-metamod.vdf"))
                 {
                     globalDisabled = true;
                     Utils.LogError("stfixes-metamod is not installed; disabling globalapi");

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -123,13 +123,13 @@ public partial class SharpTimer
                 
                 
 
-                if (Directory.Exists($"{gameDir}/addons/StripperCS2/maps/{Server.MapName}"))
+                if (Directory.Exists($"{gameDir}/csgo/addons/StripperCS2/maps/{Server.MapName}"))
                 {
                     globalDisabled = true;
                     Utils.LogError("StripperCS2 detected for current map; disabling globalapi");
                 }
                 
-                if (!Directory.Exists($"{gameDir}/addons/stfixes-metamod/"))
+                if (!Directory.Exists($"{gameDir}/csgo/addons/stfixes-metamod/"))
                 {
                     globalDisabled = true;
                     Utils.LogError("stfixes-metamod is not installed; disabling globalapi");


### PR DESCRIPTION
the plugin is checking the wrong directory, which causes the global to be disabled. I added a print to check the path its checking:

```
globaltier1  | /home/steam/cs2-dedicated/game/addons/stfixes-metamod
globaltier1  | 12:59:30 [EROR] (plugin:SharpTimer) [ST-ERROR] stfixes-metamod is not installed; disabling globalapi
```

However, !gc shows as right as it's checking for game/csgo/addons instead of /game/addons directly