### PR TITLE
saveloc + replay fix

### DIFF
--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -965,17 +965,23 @@ namespace SharpTimer
                             {
                                 if (onlySRReplay && (prevSRTimerTicks == 0 || prevSRTimerTicks > timerTicks))
                                 {
-                                    if(useBinaryReplays)
-                                        _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
-                                    else
-                                        _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    if (timerTicks < dBtimerTicks)
+                                    {
+                                        if (useBinaryReplays)
+                                            _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                        else
+                                            _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    }
                                 }
                                 else if (!onlySRReplay)
                                 {
-                                    if(useBinaryReplays)
-                                        _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
-                                    else
-                                        _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    if (timerTicks < dBtimerTicks)
+                                    {
+                                        if (useBinaryReplays)
+                                            _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                        else
+                                            _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    }
                                 }
                                 
                             }
@@ -1106,17 +1112,23 @@ namespace SharpTimer
                             {
                                 if (onlySRReplay && (prevSRTimerTicks == 0 || prevSRTimerTicks > timerTicks))
                                 {
-                                    if(useBinaryReplays)
-                                        _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
-                                    else
-                                        _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    if (timerTicks < dBtimerTicks)
+                                    {
+                                        if (useBinaryReplays)
+                                            _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                        else
+                                            _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    }
                                 }
                                 else if (!onlySRReplay)
                                 {
-                                    if(useBinaryReplays)
-                                        _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
-                                    else
-                                        _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    if (timerTicks < dBtimerTicks)
+                                    {
+                                        if (useBinaryReplays)
+                                            _ = Task.Run(async () => await DumpReplayToBinary(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                        else
+                                            _ = Task.Run(async () => await DumpReplayToJson(player!, steamId, slot, bonusX, playerTimers[slot].currentStyle, playerTimers[slot].Mode));
+                                    }
                                 }
                                 
                             }

--- a/src/Player/PlayerOnTick.cs
+++ b/src/Player/PlayerOnTick.cs
@@ -119,7 +119,7 @@ namespace SharpTimer
                         }
 
                         /* single startzone jump */
-                        if (startzoneSingleJumpEnabled)
+                        if (startzoneSingleJumpEnabled && !playerTimer.IsTimerBlocked)
                         {
                             bool wasOnGround = playerTimer.WasOnGroundLastTick;
                             playerTimer.WasOnGroundLastTick = playerPawn.GroundEntity.IsValid;


### PR DESCRIPTION
The replay system is currently buggy. If you finish the map, and then finish again with a worst time, your replay will be overwritten.

This fixes the replay save logic, and also saveloc by dont applying the singleZoneJump to players without an active timer.

Im using this on my server, and its workin fine

https://github.com/user-attachments/assets/66db7dd0-a5cd-45ab-bd77-69870041d274