### PR TITLE
Fix null reference when trigger_teleport caller entity does not have a name

### DIFF
--- a/src/Triggers/TriggerHooks.cs
+++ b/src/Triggers/TriggerHooks.cs
@@ -337,7 +337,7 @@ namespace SharpTimer
 
                 if (resetTriggerTeleportSpeedEnabled)
                 {
-                    string triggerName = caller.Entity!.Name.ToString();
+                    string triggerName = caller.Entity!.Name;
                     if (currentMapOverrideDisableTelehop != null && (!currentMapOverrideDisableTelehop!.Contains(triggerName) || currentMapOverrideDisableTelehop![0].ToLower() == "true"))
                     {
                         Action<CCSPlayerController?, float, bool> adjustVelocity = use2DSpeed ? AdjustPlayerVelocity2D : AdjustPlayerVelocity;


### PR DESCRIPTION
Removed .ToString() as Name property is string. This caused an exception when Name is null