### PR TITLE
Fix css_timer exploit allowing unfair advantages via noclip.

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -1596,6 +1596,8 @@ namespace SharpTimer
             // fix timer toggle bug
             if (!playerTimers[slot].IsTimerBlocked)
             {
+                // Teleport player to start when resuming timer to prevent exploit
+                RespawnPlayer(player);
                 Vector_t playerPos = player.Pawn?.Value!.CBodyComponent?.SceneNode!.AbsOrigin.ToVector_t() ?? new();
                 bool isInsideStartBox = Utils.IsVectorInsideBox(playerPos, currentMapStartC1, currentMapStartC2, true);
                 playerTimers[slot].inStartzone = isInsideStartBox; // Only set to true if player is actually in the start zone


### PR DESCRIPTION
## Issue

Players could exploit css_timer by:
1. Pausing timer with css_timer
2. Using noclip to fly to advantageous positions
3. Resuming timer without position reset
## Solution
When resuming timer, now respawns player to start position automatically.