### PR TITLE
Fix SQLite PlayerStats upsert dropping HideChatSpeed (14 values for 15 columns)

### DIFF
--- a/src/DB/DatabaseUtils.cs
+++ b/src/DB/DatabaseUtils.cs
@@ -1445,7 +1445,7 @@ namespace SharpTimer
                                     break;
                                 case DatabaseType.SQLite:
                                     upsertQuery =
-                                        $@"REPLACE INTO {PlayerStatsTable} (PlayerName, SteamID, TimesConnected, LastConnected, HideTimerHud, HideKeys, SoundsEnabled, PlayerFov, IsVip, BigGifID, GlobalPoints, HideWeapon, HidePlayers, Mode, HideChatSpeed) VALUES (@PlayerName, @SteamID, @TimesConnected, @LastConnected, @HideTimerHud, @HideKeys, @SoundsEnabled, @PlayerFov, @IsVip, @BigGifID, @GlobalPoints, @HideWeapon, @HidePlayers, @Mode)";
+                                        $@"REPLACE INTO {PlayerStatsTable} (PlayerName, SteamID, TimesConnected, LastConnected, HideTimerHud, HideKeys, SoundsEnabled, PlayerFov, IsVip, BigGifID, GlobalPoints, HideWeapon, HidePlayers, Mode, HideChatSpeed) VALUES (@PlayerName, @SteamID, @TimesConnected, @LastConnected, @HideTimerHud, @HideKeys, @SoundsEnabled, @PlayerFov, @IsVip, @BigGifID, @GlobalPoints, @HideWeapon, @HidePlayers, @Mode, @HideChatSpeed)";
                                     upsertCommand = new SqliteCommand(upsertQuery, (SqliteConnection)connection);
                                     break;
                                 default:


### PR DESCRIPTION
## Summary
The SQLite branch of the new-player `PlayerStats` upsert in `GetPlayerStats` lists 15 columns but supplies only 14 values, omitting `@HideChatSpeed`. On SQLite this throws on every player connect:

    SQLite Error 1: '14 values for 15 columns'
    at SharpTimer.SharpTimer.GetPlayerStats(...) in src/DB/DatabaseUtils.cs

Because the insert fails, the player's stats row is never written, so their preferences (HideTimerHud / HideKeys / SoundsEnabled / PlayerFov / IsVip / HideWeapon / HidePlayers / HideChatSpeed) never persist.

## Root cause
`GetPlayerStats`, SQLite case:

    REPLACE INTO {PlayerStatsTable} (... , Mode, HideChatSpeed)
    VALUES (... , @Mode)

The column list ends `Mode, HideChatSpeed` (15) but VALUES ends `@Mode` (14). The `@HideChatSpeed` parameter is even added a few lines below, it is just never referenced by the SQLite query. The MySQL and PostgreSQL branches in the same block already pass `@HideChatSpeed`; the SQLite branch was the only one missed. (Three of the four other SQLite `PlayerStats` inserts in this file already include it; this one did not.) `HideChatSpeed` was added by migration 007, so any migrated SQLite server hits this on every connect.

## Fix
Append `, @HideChatSpeed` to the SQLite VALUES clause, matching the MySQL/PostgreSQL branches.

## Testing
Built clean (0 warnings / 0 errors). Verified live on a SQLite surf server: the per-connect error is gone and PlayerStats rows persist correctly.
