### PR TITLE
Fix css_sr never returning a record: missing map/mode filter args

### DIFF
--- a/src/Commands/ChatCommands.cs
+++ b/src/Commands/ChatCommands.cs
@@ -947,7 +947,7 @@ namespace SharpTimer
 
             Utils.LogDebug($"Handling !sr for {_playerName}...");
             
-            var sortedRecords = await GetSortedRecordsFromDatabase();
+            var sortedRecords = await GetSortedRecordsFromDatabase(1, 0, "", 0, GetModeName(defaultMode));
 
             if (sortedRecords.Count == 0)
                 return;


### PR DESCRIPTION
## Summary
`!sr` (`css_sr`) returns nothing even on maps that have records.

## Root cause
`SRCommandHandler` calls `GetSortedRecordsFromDatabase()` with all default arguments:

    var sortedRecords = await GetSortedRecordsFromDatabase();

That method filters `WHERE MapName = @MapName AND Style = @Style AND Mode = @Mode`. With no arguments `mapName` resolves to the current map (fine), but `mode` stays `""`. Records are written under the real mode name (`GetModeName(defaultMode)`, e.g. `"Custom"`), so `Mode = ''` matches nothing and the handler early-returns on `sortedRecords.Count == 0`. Every other caller (`PrintTopRecordsHandler` / `!top`, the rank-tag path, and the cached SR fetch in `Plugin.cs`) passes the real mode; `css_sr` is the one that does not.

## Fix
Pass the server-record arguments explicitly, mirroring the cached SR fetch already in `Plugin.cs`:

    var sortedRecords = await GetSortedRecordsFromDatabase(1, 0, "", 0, GetModeName(defaultMode));

## Testing
Built clean (0/0). Verified live on a SQLite surf server with existing records: `!sr` now prints the map's #1 time.
