### PR TITLE
Guard null Controller.Value in trigger hooks (fixes recurring 'Object reference not set', #178)

### DIFF
--- a/src/Triggers/TriggerHooks.cs
+++ b/src/Triggers/TriggerHooks.cs
@@ -31,7 +31,9 @@ namespace SharpTimer
 
                 if (activator.DesignerName != "player" || useTriggers == false) return HookResult.Continue;
 
-                var player = new CCSPlayerController(new CCSPlayerPawn(activator.Handle).Controller.Value!.Handle);
+                var stCtrl = new CCSPlayerPawn(activator.Handle).Controller.Value;
+                if (stCtrl == null) return HookResult.Continue;
+                var player = new CCSPlayerController(stCtrl.Handle);
 
                 if (player == null)
                 {
@@ -191,7 +193,9 @@ namespace SharpTimer
 
                 if (activator.DesignerName != "player" || useTriggers == false) return HookResult.Continue;
 
-                var player = new CCSPlayerController(new CCSPlayerPawn(activator.Handle).Controller.Value!.Handle);
+                var stCtrl = new CCSPlayerPawn(activator.Handle).Controller.Value;
+                if (stCtrl == null) return HookResult.Continue;
+                var player = new CCSPlayerController(stCtrl.Handle);
 
                 if (player == null)
                 {
@@ -291,7 +295,9 @@ namespace SharpTimer
                     return HookResult.Continue;
                 }
 
-                var player = new CCSPlayerController(new CCSPlayerPawn(activator.Handle).Controller.Value!.Handle);
+                var stCtrl = new CCSPlayerPawn(activator.Handle).Controller.Value;
+                if (stCtrl == null) return HookResult.Continue;
+                var player = new CCSPlayerController(stCtrl.Handle);
 
                 if (player == null || player.IsBot || player.IsHLTV || !player.IsValid)
                 {
@@ -328,7 +334,9 @@ namespace SharpTimer
                     return HookResult.Continue;
                 }
 
-                var player = new CCSPlayerController(new CCSPlayerPawn(activator.Handle).Controller.Value!.Handle);
+                var stCtrl = new CCSPlayerPawn(activator.Handle).Controller.Value;
+                if (stCtrl == null) return HookResult.Continue;
+                var player = new CCSPlayerController(stCtrl.Handle);
 
                 if (player == null || player.IsBot || player.IsHLTV || !player.IsValid)
                 {


### PR DESCRIPTION
## Summary
Four trigger-output hooks in `TriggerHooks.cs` dereference a pawn's controller with `.Value!` and no null check:

    var player = new CCSPlayerController(new CCSPlayerPawn(activator.Handle).Controller.Value!.Handle);

(the `trigger_multiple` OnStartTouch/OnEndTouch and the two `trigger_teleport` equivalents). When a pawn has no controller, transient during disconnect or a round/map transition, `.Value` is null and `.Value!.Handle` throws `NullReferenceException`. Each hook has a surrounding try/catch that logs `Object reference not set to an instance of an object.` and continues, so it is not fatal, but on a busy server it fires constantly and the repeated throw/catch is measurable overhead. This is the symptom reported in #178.

## Fix
Resolve `.Controller.Value` into a local, null-check it, and return `HookResult.Continue` when null, identical to the existing `activator == null` guards already in these methods. Behaviour is unchanged when the controller is present. Applied to all four sites.

## Testing
Built clean (0/0). Verified live on a surf server: the recurring `trigger_multiple OnEndTouch` "Object reference not set" spam is gone.

Closes #178.
